### PR TITLE
Improve the the display of service binding information

### DIFF
--- a/lambda/src/app/lambdas/lambda-details/lambda-instance-bindings/lambda-instance-bindings.component.html
+++ b/lambda/src/app/lambdas/lambda-details/lambda-instance-bindings/lambda-instance-bindings.component.html
@@ -13,7 +13,7 @@
     <div class="col-8">Environment Variable Name</div>
     <div class="col-1"></div>
   </div>
-  <div class="row sf-list__body" *ngFor="let instanceBinding of instanceBindingInfoList; let i = index">
+  <div class="row sf-list__body" *ngFor="let instanceBinding of instanceBindingInfoList; let i = index; last as isLast">
     <div class="col-3">
       {{ instanceBinding.instanceName }}
     </div>
@@ -26,6 +26,9 @@
     </div>
     <div class="col-1">
       <button class="tn-icon tn-icon--delete tn-button tn-button--small tn-button--icon tn-button--text" (click)="remove(i)"></button>
+    </div>
+    <div class="col-12" *ngIf="!isLast">
+      <hr>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Changes proposed in this pull request:

 - The Service binding info should is now improved
   with a line dividing between different service
   binding usages.

Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
---




