### PR TITLE
Make nouns singular for one instance

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -31,7 +31,7 @@ To simplify development, set up another instance of the Console application serv
 - Run `npm i ng-cli` to install angular CLI
 - Update your `/etc/hosts` file to include `127.0.0.1 console-dev.kyma.local`
 - Run the command `npm start` to serve the console locally,
-- Access tho local instance of Console in the browser at `http://console-dev.kyma.local:4200`
+- Access the local instance of Console in the browser at `http://console-dev.kyma.local:4200`
 - Login to Console as `admin@kyma.cx`
 
 

--- a/core/src/app/content/environments/environment-details/environment-details.component.html
+++ b/core/src/app/content/environments/environment-details/environment-details.component.html
@@ -8,81 +8,86 @@
             <span>{{ environment.getLabel() }}</span>
         </h1>
         <div class="sf-toolbar__right">
-                    <button class="tn-button tn-button--text tn-button--small sf-toolbar__item" (click)="openUploadResourceModal()" *ngIf="!showSelectFileButton">
-            + Deploy new resource to the environment
-        </button>
+            <button class="tn-button tn-button--text tn-button--small sf-toolbar__item" (click)="openUploadResourceModal()"
+                *ngIf="!showSelectFileButton">
+                + Deploy new resource to the environment
+            </button>
         </div>
     </div>
-      <div class="sf-section">
-    <div class="row">
-        <div class="col">
-            <div class="sf-panel">
-                <div class="sf-panel__content">
-                    <div class="tn-form__group">
+    <div class="sf-section">
+        <div class="row">
+            <div class="col">
+                <div class="sf-panel">
+                    <div class="sf-panel__content">
+                        <div class="tn-form__group">
+                            <div class="tn-form__group">
+                                <div class="tn-form__item">
+                                    <label class="tn-form__label">Name</label>
+                                    <input class="tn-form__control" type="text" value="{{environment.getLabel()}}"
+                                        readonly>
+                                </div>
+                            </div>
+                        </div>
                         <div class="tn-form__group">
                             <div class="tn-form__item">
-                                <label class="tn-form__label">Name</label>
-                                <input class="tn-form__control" type="text" value="{{environment.getLabel()}}" readonly>
+                                <label class="tn-form__label">Environment-ID</label>
+                                <input class="tn-form__control" type="text" value="{{environment.getUid()}}" readonly>
                             </div>
                         </div>
                     </div>
-                    <div class="tn-form__group">
-                        <div class="tn-form__item">
-                            <label class="tn-form__label">Environment-ID</label>
-                            <input class="tn-form__control" type="text" value="{{environment.getUid()}}" readonly>
-                        </div>
                 </div>
+            </div>
+            <div class="col">
+                <div class="sf-panel sf-panel-counters">
+                    <div class="sf-panel__content">
+                        <div class="row">
+                            <div class="col">
+                                <div class="sf-sku sf-sku--center">
+                                    <span class="sf-sku__value">{{ services ? services.length : 0 }}</span>
+                                    <a class="sf-sku__label" routerLink="../services">{{ services &&
+                                        (services.length===1)
+                                        ? "Service" : "Services" }}</a>
+                                </div>
+                            </div>
+                            <div class="col">
+                                <div class="sf-sku sf-sku--center">
+                                    <span class="sf-sku__value">{{ boundRemoteEnvironmentsCount | async }}</span>
+                                    <span>{{ (boundRemoteEnvironmentsCount | async) ===1 ? "Bound Remote Environment" :
+                                        "Bound Remote Environments"}}</span>
+                                    <a class="sf-sku__label" routerLink="/home/settings/remoteEnvs">Show All Remote
+                                        Environments</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="col">
-            <div class="sf-panel sf-panel-counters">
-                <div class="sf-panel__content">
-                    <div class="row">
-                        <div class="col">
-                            <div class="sf-sku sf-sku--center">
-                                <span class="sf-sku__value">{{ services ? services.length : 0 }}</span>
-                                <a class="sf-sku__label" routerLink="../services">Services</a>
-                            </div>
-                        </div>
-                        <div class="col">
-                            <div class="sf-sku sf-sku--center">
-                                <span class="sf-sku__value">{{ boundRemoteEnvironmentsCount | async }}</span>
-                                <span>Bound Remote Environments</span>
-                                <a class="sf-sku__label" routerLink="/home/settings/remoteEnvs">Show All Remote Environments</a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
     </div>
-    </div>
-</div>
 
     <div class="sf-section" *ngIf="remoteEnvironments && remoteEnvironments.length > 0">
         <div class="sf-panel">
             <div class="sf-panel__head">
                 <h2 class="sf-section__headline">Connected Remote Environments</h2>
             </div>
-        <table class="sf-table">
-            <thead class="sf-table__head">
-                <th class="sf-table__th">Name</th>
-                <th class="sf-table__th">Actions</th>
-            </thead>
-            <tbody class="sf-table__body">
-                <tr *ngFor="let env of remoteEnvironments">
-                    <td class="sf-table__td sf-table__td--primary">
-                        <a routerLink="/home/settings/remoteEnvs/{{env.name}}">{{ env.name }}</a>
-                    </td>
-                    <td class="sf-table__td sf-table__td--min sf-table__td--text-right">
-                      <y-list-actions [entry]="env" [entryEventHandler]="entryEventHandler"
-                                      [actions]="actions"></y-list-actions>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+            <table class="sf-table">
+                <thead class="sf-table__head">
+                    <th class="sf-table__th">Name</th>
+                    <th class="sf-table__th">Actions</th>
+                </thead>
+                <tbody class="sf-table__body">
+                    <tr *ngFor="let env of remoteEnvironments">
+                        <td class="sf-table__td sf-table__td--primary">
+                            <a routerLink="/home/settings/remoteEnvs/{{env.name}}">{{ env.name }}</a>
+                        </td>
+                        <td class="sf-table__td sf-table__td--min sf-table__td--text-right">
+                            <y-list-actions [entry]="env" [entryEventHandler]="entryEventHandler" [actions]="actions"></y-list-actions>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
-</div>
 </div>
 
 <app-resource-uploader-modal #uploaderModal></app-resource-uploader-modal>

--- a/core/src/app/content/workspace-overview/environment-card/environment-card.component.html
+++ b/core/src/app/content/workspace-overview/environment-card/environment-card.component.html
@@ -1,6 +1,5 @@
-<div class="tn-card tn-card--button" routerLink="/home/environments/{{entry.getId()}}"
-[ngClass]="{'sf-list__disabled': disabled === true}">
-<div class="tn-card__content">
+<div class="tn-card tn-card--button" routerLink="/home/environments/{{entry.getId()}}" [ngClass]="{'sf-list__disabled': disabled === true}">
+  <div class="tn-card__content">
     <div class="row">
       <div class="col">
         <h2 class="tn-card__header">{{ entry.getLabel() }}</h2>
@@ -13,21 +12,20 @@
       <div class="col">
         <div class="sf-sku">
           <span class="sf-sku__value">{{ entry.services && (entry.services | async) !== null ? (entry.services | async) : 0 }}</span>
-          <span class="sf-sku__label">Services</span>
+          <span class="sf-sku__label">{{ (entry.services | async) === 1 ? "Service" : "Services" }}</span>
         </div>
       </div>
       <div class="col">
         <div class="sf-sku">
           <span class="sf-sku__value">{{ entry.remoteEnvs && (entry.remoteEnvs | async) !== null ? (entry.remoteEnvs | async) : 0 }}</span>
-          <span class="sf-sku__label">Bound Remote Environments</span>
+          <span class="sf-sku__label">{{ (entry.remoteEnvs |async) === 1 ? "Bound Remote Environment":"Bound Remote Environments" }}</span>
         </div>
       </div>
     </div>
     <div class="row">
       <div class="col text-right">
         <span style="font-size: smaller; color: grey;">{{ entry.getUid() }}</span>
-    </div>
+      </div>
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:

- In the overview page, "services" word is plural even if there is only 1 service. Albeit trivial, I saw it as a good "beginner-friendly" bug. Here is a [link](https://english.stackexchange.com/questions/38293/why-is-zero-followed-by-a-plural-noun) on why zero is still plural. The screenshot shows new view. 
- This PR also fixes a typo in readme.md
![capture](https://user-images.githubusercontent.com/7947572/43779448-b92c6730-9a58-11e8-9f15-b7a0e04698c8.PNG)


<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
