### PR TITLE
Add tags and longDescription in ServiceClassDetails component

### DIFF
--- a/catalog/OSBAContract.md
+++ b/catalog/OSBAContract.md
@@ -18,14 +18,14 @@ Catalog-ui directly uses the [ui-api-layer](https://github.com/kyma-project/kyma
 
 ## Catalog Details page
 
-| Number | OSBA field                   | Fallbacks  | Description                                                       |
-| ------ | ---------------------------- | ---------- | ----------------------------------------------------------------- |
-| (1)    | description\*                | -          | If not provided, the `General Information` panel does not appear. |
-| (2)    | not related to OSBA          | -          | -                                                                 |
-| (3)    | metadata.documentationUrl    | -          | If not provided, the link with documentation does not appear.     |
-| (4)    | metadata.displayName         | name*, id* | -                                                                 |
-| (5)    | metadata.providerDisplayName | -          | If not provided, UI displays without this information.            |
-| (6)    | not related to OSBA          | -          | -                                                                 |
+| Number | OSBA field                   | Fallbacks      | Description                                                       |
+| ------ | ---------------------------- | -------------- | ----------------------------------------------------------------- |
+| (1)    | metadata.longDescription     | description\*  | If not provided, the `General Information` panel does not appear. |
+| (2)    | not related to OSBA          | -              | -                                                                 |
+| (3)    | metadata.documentationUrl    | -              | If not provided, the link with documentation does not appear.     |
+| (4)    | metadata.displayName         | name*, id*     | -                                                                 |
+| (5)    | metadata.providerDisplayName | -              | If not provided, UI displays without this information.            |
+| (6)    | not related to OSBA          | -              | -                                                                 |
 
 \*Fields with an asterisk are required OSBA attributes.
 

--- a/catalog/src/commons/helpers.js
+++ b/catalog/src/commons/helpers.js
@@ -39,6 +39,14 @@ export const getResourceDisplayName = resource => {
   return resource.displayName || resource.externalName || resource.name;
 };
 
+export const getDescription = resource => {
+  if (!resource) {
+    return null;
+  }
+
+  return resource.longDescription || resource.description;
+};
+
 export function clearEmptyPropertiesInObject(object) {
   for (const key in object) {
     if (typeof object[key] === 'undefined' || object[key] === '') {

--- a/catalog/src/components/ServiceClassDetails/ServiceClassDetails.component.js
+++ b/catalog/src/components/ServiceClassDetails/ServiceClassDetails.component.js
@@ -15,7 +15,7 @@ import {
   CenterSideWrapper,
 } from './styled';
 
-import { getResourceDisplayName } from '../../commons/helpers';
+import { getResourceDisplayName, getDescription } from '../../commons/helpers';
 
 class ServiceClassDetails extends React.Component {
   static propTypes = {
@@ -30,6 +30,8 @@ class ServiceClassDetails extends React.Component {
     const serviceClassDisplayName = getResourceDisplayName(
       serviceClass.serviceClass,
     );
+
+    const serviceClassDescription = getDescription(serviceClass.serviceClass);
 
     const modalOpeningComponent = (
       <Button normal primary first last microFullWidth data-e2e-id="add-to-env">
@@ -68,12 +70,13 @@ class ServiceClassDetails extends React.Component {
                   }
                   documentationUrl={serviceClass.serviceClass.documentationUrl}
                   imageUrl={serviceClass.serviceClass.imageUrl}
+                  tags={serviceClass.serviceClass.tags}
                 />
               </LeftSideWrapper>
               <CenterSideWrapper>
-                {serviceClass.serviceClass.description && (
+                {serviceClassDescription && (
                   <ServiceClassDescription
-                    description={serviceClass.serviceClass.description}
+                    description={serviceClassDescription}
                   />
                 )}
                 {serviceClass.serviceClass.content ||

--- a/catalog/src/components/ServiceClassDetails/ServiceClassInfo/ServiceClassInfo.component.js
+++ b/catalog/src/components/ServiceClassDetails/ServiceClassInfo/ServiceClassInfo.component.js
@@ -11,6 +11,8 @@ import {
   ServiceProvider,
   DocsLink,
   Image,
+  TagsWrapper,
+  Tag,
 } from './styled';
 
 const ServiceClassInfo = ({
@@ -19,7 +21,12 @@ const ServiceClassInfo = ({
   creationTimestamp,
   documentationUrl,
   imageUrl,
+  tags,
 }) => {
+  function sortTags(tag1, tag2) {
+    return tag1.length > 8 && tag2.length < 15;
+  }
+
   return (
     <div>
       <ServiceClassInfoContentWrapper>
@@ -52,6 +59,12 @@ const ServiceClassInfo = ({
             </DocsLink>
           </Text>
         )}
+        {tags &&
+          tags.length > 0 && (
+            <TagsWrapper>
+              {[...tags].sort(sortTags).map(tag => <Tag key={tag}>{tag}</Tag>)}
+            </TagsWrapper>
+          )}
       </div>
     </div>
   );
@@ -63,6 +76,7 @@ ServiceClassInfo.propTypes = {
   creationTimestamp: PropTypes.number,
   documentationUrl: PropTypes.string,
   imageUrl: PropTypes.string,
+  tags: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default ServiceClassInfo;

--- a/catalog/src/components/ServiceClassDetails/ServiceClassInfo/styled.js
+++ b/catalog/src/components/ServiceClassDetails/ServiceClassInfo/styled.js
@@ -59,3 +59,32 @@ export const DocsLink = styled.a`
   font-size: 14px;
   font-weight: normal;
 `;
+
+export const TagsWrapper = styled.div`
+  margin-top: 32px;
+  width: 100%;
+  height: auto;
+`;
+
+export const Tag = styled.span`
+  max-width: 220px;
+  display: inline-block;
+  mix-blend-mode: multiply;
+  border-radius: 4px;
+  background-color: #e2eaf2;
+  font-size: 12px;
+  font-family: 72;
+  font-weight: 300;
+  text-transform: uppercase;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: #73787d;
+  padding: 6px 10px;
+  margin: 0 10px 10px 0;
+`;

--- a/catalog/src/components/ServiceClassDetails/queries.js
+++ b/catalog/src/components/ServiceClassDetails/queries.js
@@ -8,6 +8,7 @@ export const GET_SERVICE_CLASS = gql`
       displayName
       creationTimestamp
       description
+      longDescription
       documentationUrl
       imageUrl
       providerDisplayName


### PR DESCRIPTION
Confirm these statements before you submit your pull request:

- [x] I have read and submitted the required [Contributor Licence Agreements](https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
- [x] This pull request follows the contributing guidelines, recommended Git workflow, and templates.
- [x] I have tested my changes.
- [x] I have updated the relevant documentation.
---

**Description**

Changes proposed in this pull request:
- Add **longDescription** in ServiceClass query.
- Display in `ServiceClassDetails` component **longDescription** value in `General Information` panel. If **longDescription** is not present, the `General Information` panel displays **description** value. If it also is not present, the `General Information` panel does not appear.
- Add tags below basic `Vendor` information (at this moment not clickable).