### PR TITLE
Luigi integration in service-catalog and instances

### DIFF
--- a/catalog/package-lock.json
+++ b/catalog/package-lock.json
@@ -152,6 +152,11 @@
         }
       }
     },
+    "@kyma-project/luigi-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kyma-project/luigi-client/-/luigi-client-0.3.2.tgz",
+      "integrity": "sha512-gB3+MFTU4+DvEYphPTXZb8/zo/MNUOkA0DKijkH3YsjvYa3m3dNCqxv0TWgZp4s1buGQ/v97gQh1nowrgSMHAg=="
+    },
     "@kyma-project/react-components": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@kyma-project/react-components/-/react-components-0.0.20.tgz",

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@kyma-project/react-components": "^0.0.20",
+    "@kyma-project/luigi-client": "0.3.2",
     "ajv": "^6.0.0",
     "apollo-boost": "^0.1.3",
     "deep-copy": "^1.4.2",

--- a/catalog/src/components/App/App.component.js
+++ b/catalog/src/components/App/App.component.js
@@ -2,9 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Switch, Route } from 'react-router-dom';
 import { Modal, Notification } from '@kyma-project/react-components';
+import LuigiClient from '@kyma-project/luigi-client';
 
 import MainPage from '../Main/Main.container';
 import InstanceDetails from '../ServiceClassDetails/ServiceClassDetails.container';
+
+import { NotificationLink } from './styled';
 
 Modal.MODAL_APP_REF = '#root';
 const NOTIFICATION_VISIBILITY_TIME = 5000;
@@ -36,6 +39,12 @@ class App extends React.Component {
     this.props.clearNotification();
   };
 
+  goToServiceInstanceDetails = name => {
+    LuigiClient.linkManager()
+      .fromContext('environment')
+      .navigate(`instances/details/${name}`);
+  };
+
   render() {
     const notificationQuery = this.props.notification;
     const notification = notificationQuery && notificationQuery.notification;
@@ -45,7 +54,21 @@ class App extends React.Component {
 
     return (
       <div>
-        <Notification {...notification} onClick={this.clearNotification} />
+        {notification && (
+          <Notification
+            {...notification}
+            title={
+              <NotificationLink
+                onClick={() => {
+                  this.goToServiceInstanceDetails(notification.instanceName);
+                }}
+              >
+                {notification.title}
+              </NotificationLink>
+            }
+            onClick={this.clearNotification}
+          />
+        )}
         <div className="ph3 pv1 background-gray">
           <Switch>
             <Route exact path="/" component={MainPage} />

--- a/catalog/src/components/App/queries.js
+++ b/catalog/src/components/App/queries.js
@@ -7,6 +7,7 @@ export const GET_NOTIFICATION = gql`
       color
       icon
       visible
+      instanceName
     }
   }
 `;

--- a/catalog/src/components/App/styled.js
+++ b/catalog/src/components/App/styled.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const NotificationLink = styled.a`
+  font-family: '72';
+  font-size: 14px;
+  font-weight: normal;
+`;

--- a/catalog/src/components/ServiceClassDetails/CreateInstanceModal/BasicData.component.js
+++ b/catalog/src/components/ServiceClassDetails/CreateInstanceModal/BasicData.component.js
@@ -138,7 +138,8 @@ class BasicData extends React.Component {
     const { data, error } = await this.props.refetchInstanceExists(name);
 
     this.setState({
-      instanceWithNameAlreadyExists: !error && data.serviceInstance !== null,
+      instanceWithNameAlreadyExists:
+        !error && data && data.serviceInstance !== null,
     });
   };
 

--- a/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.component.js
+++ b/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.component.js
@@ -177,6 +177,7 @@ class CreateInstanceModal extends React.Component {
             title: `Instance "${variables.name}" created successfully`,
             color: '#359c46',
             icon: '\uE05B',
+            instanceName: variables.name,
           },
         });
       }

--- a/catalog/src/components/ServiceClassDetails/CreateInstanceModal/mutations.js
+++ b/catalog/src/components/ServiceClassDetails/CreateInstanceModal/mutations.js
@@ -1,8 +1,18 @@
 import gql from 'graphql-tag';
 
 export const SEND_NOTIFICATION = gql`
-  mutation sendNotification($title: String!, $color: String!, $icon: String!) {
-    sendNotification(title: $title, color: $color, icon: $icon) @client {
+  mutation sendNotification(
+    $title: String!
+    $color: String!
+    $icon: String!
+    $instanceName: String!
+  ) {
+    sendNotification(
+      title: $title
+      color: $color
+      icon: $icon
+      instanceName: $instanceName
+    ) @client {
       title
     }
   }

--- a/catalog/src/components/ServiceClassList/Cards/Cards.component.js
+++ b/catalog/src/components/ServiceClassList/Cards/Cards.component.js
@@ -1,15 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import LuigiClient from '@kyma-project/luigi-client';
 
 import Card from './Card.component';
 
 import { getResourceDisplayName } from '../../../commons/helpers';
 
 const Cards = ({ items, history }) => {
+  const goToServiceClassDetails = name => {
+    LuigiClient.linkManager()
+      .fromContext('environment')
+      .navigate(`service-catalog/details/${name}`);
+  };
+
   return items.map(item => (
     <Card
       key={item.name}
-      onClick={() => history.push(`/details/${item.name}`)}
+      onClick={() => goToServiceClassDetails(item.name)}
       title={getResourceDisplayName(item)}
       company={item.providerDisplayName}
       description={item.description}

--- a/instances/package-lock.json
+++ b/instances/package-lock.json
@@ -152,6 +152,11 @@
         }
       }
     },
+    "@kyma-project/luigi-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kyma-project/luigi-client/-/luigi-client-0.3.2.tgz",
+      "integrity": "sha512-gB3+MFTU4+DvEYphPTXZb8/zo/MNUOkA0DKijkH3YsjvYa3m3dNCqxv0TWgZp4s1buGQ/v97gQh1nowrgSMHAg=="
+    },
     "@kyma-project/react-components": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@kyma-project/react-components/-/react-components-0.0.20.tgz",

--- a/instances/package.json
+++ b/instances/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "dependencies": {
     "@kyma-project/react-components": "^0.0.20",
+    "@kyma-project/luigi-client": "0.3.2",
     "ajv": "^6.0.0",
     "apollo-boost": "^0.1.3",
     "graphql": "^0.13.2",

--- a/instances/src/components/ServiceInstanceDetails/ServiceInstanceToolbar/ServiceInstanceToolbar.component.js
+++ b/instances/src/components/ServiceInstanceDetails/ServiceInstanceToolbar/ServiceInstanceToolbar.component.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import LuigiClient from '@kyma-project/luigi-client';
 
 import {
   Button,
@@ -8,7 +9,7 @@ import {
 
 import {
   ServiceInstanceToolbarHeadline,
-  ServiceInstanceToolbarHeadlineBlue,
+  ServiceInstanceToolbarHeadlineLink,
 } from './styled';
 
 const ServiceInstanceToolbar = ({
@@ -23,13 +24,19 @@ const ServiceInstanceToolbar = ({
     }, 300);
   };
 
+  const goToServiceInstances = () => {
+    LuigiClient.linkManager()
+      .fromContext('environment')
+      .navigate('instances');
+  };
+
   return (
     <Toolbar
       headline={
         <ServiceInstanceToolbarHeadline>
-          <ServiceInstanceToolbarHeadlineBlue style={{ color: '#0b74de' }}>
+          <ServiceInstanceToolbarHeadlineLink onClick={goToServiceInstances}>
             Service Instances
-          </ServiceInstanceToolbarHeadlineBlue>{' '}
+          </ServiceInstanceToolbarHeadlineLink>{' '}
           / {serviceInstance.name}
         </ServiceInstanceToolbarHeadline>
       }

--- a/instances/src/components/ServiceInstanceDetails/ServiceInstanceToolbar/styled.js
+++ b/instances/src/components/ServiceInstanceDetails/ServiceInstanceToolbar/styled.js
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 
 export const ServiceInstanceToolbarHeadline = styled.header``;
 
-export const ServiceInstanceToolbarHeadlineBlue = styled.span`
+export const ServiceInstanceToolbarHeadlineLink = styled.a`
   color: #0b74de;
+  text-decoration: none !important;
+  cursor: pointer;
 `;

--- a/instances/src/components/ServiceInstances/ServiceInstancesTable/ServiceInstancesTable.component.js
+++ b/instances/src/components/ServiceInstances/ServiceInstancesTable/ServiceInstancesTable.component.js
@@ -1,15 +1,19 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import LuigiClient from '@kyma-project/luigi-client';
 
 import {
   Button,
   Icon,
   ConfirmationModal,
   Table,
-  // Tooltip,
 } from '@kyma-project/react-components';
 
-import { LinkButton, ServiceClassButton } from './styled';
+import {
+  LinkButton,
+  Link,
+  ServiceClassButton,
+  AddServiceRedirectButton,
+} from './styled';
 
 import { getResourceDisplayName, statusColor } from '../../../commons/helpers';
 
@@ -40,12 +44,30 @@ function ServiceInstancesTable({
     }
   };
 
+  const goToServiceCatalog = () => {
+    LuigiClient.linkManager()
+      .fromContext('environment')
+      .navigate('service-catalog');
+  };
+
+  const goToServiceInstanceDetails = name => {
+    LuigiClient.linkManager()
+      .fromContext('environment')
+      .navigate(`instances/details/${name}`);
+  };
+
   const deleteButton = (
     <div style={{ textAlign: 'right' }}>
       <Button padding={'0'} marginTop={'0'} marginBottom={'0'}>
         <Icon icon={'\uE03D'} />
       </Button>
     </div>
+  );
+
+  const addServiceRedirectButton = (
+    <AddServiceRedirectButton onClick={goToServiceCatalog}>
+      + Add Service
+    </AddServiceRedirectButton>
   );
 
   const table = {
@@ -57,7 +79,7 @@ function ServiceInstancesTable({
         accesor: el => (
           <LinkButton data-e2e-id="instance-name">
             <Link
-              to={`/details/${el.name}`}
+              onClick={() => goToServiceInstanceDetails(el.name)}
               data-e2e-id={`instance-name-${el.name}`}
             >
               {el.name}
@@ -138,6 +160,7 @@ function ServiceInstancesTable({
   return (
     <Table
       title={table.title}
+      addHeaderContent={addServiceRedirectButton}
       columns={table.columns}
       data={table.data}
       loading={loading}

--- a/instances/src/components/ServiceInstances/ServiceInstancesTable/styled.js
+++ b/instances/src/components/ServiceInstances/ServiceInstancesTable/styled.js
@@ -3,12 +3,33 @@ import styled from 'styled-components';
 export const LinkButton = styled.span`
   color: #0b74de;
   font-weight: bold;
+  text-decoration: none;
+  cursor: pointer;
+`;
 
-  > a {
-    text-decoration: none;
-  }
+export const Link = styled.a`
+  cursor: pointer;
+  text-decoration: none !important;
 `;
 
 export const ServiceClassButton = styled.span`
   color: #0a6ed1;
+`;
+
+export const AddServiceRedirectButton = styled.button`
+  padding: 0;
+  background: none;
+  border: 0;
+  font-size: 14px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.21;
+  letter-spacing: normal;
+  text-align: right;
+  margin-right: 0;
+  color: #0a6ed1;
+  opacity: 1;
+  text-decoration: none;
+  cursor: pointer;
 `;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Add link in `ServiceInstances` view to `service-catalog`
- Direct link to details of a specific service class
- Direct link to details of a specific service instance
- The instance provisioning indicator/message contains a link to the details of new created instance

**Related issue(s)**
See also #109 
