### PR TITLE
Improve server response to send assets

### DIFF
--- a/catalog/nginx.conf
+++ b/catalog/nginx.conf
@@ -14,6 +14,7 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
   gzip on;
+  gzip_types    text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
   keepalive_timeout 5;
   keepalive_requests 200;
   reset_timedout_connection on;

--- a/content/nginx.conf
+++ b/content/nginx.conf
@@ -14,6 +14,7 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
   gzip on;
+  gzip_types    text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
   keepalive_timeout 5;
   keepalive_requests 200;
   reset_timedout_connection on;

--- a/core/nginx/nginx.conf
+++ b/core/nginx/nginx.conf
@@ -27,6 +27,7 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
+    gzip_types    text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
 
     server {
         listen       8080 http2;

--- a/core/nginx/nginx.conf
+++ b/core/nginx/nginx.conf
@@ -21,11 +21,12 @@ http {
     access_log  /var/log/nginx/access.log  main;
 
     sendfile        off;
-    #tcp_nopush     on;
+    tcp_nopush on;
+    tcp_nodelay on;
 
     keepalive_timeout  65;
 
-    #gzip  on;
+    gzip  on;
 
     server {
         listen       8080 http2;

--- a/instances/nginx.conf
+++ b/instances/nginx.conf
@@ -14,6 +14,7 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
   gzip on;
+  gzip_types    text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
   keepalive_timeout 5;
   keepalive_requests 200;
   reset_timedout_connection on;

--- a/lambda/nginx/nginx.conf
+++ b/lambda/nginx/nginx.conf
@@ -21,11 +21,12 @@ http {
     access_log  /var/log/nginx/access.log  main;
 
     sendfile        off;
-    #tcp_nopush     on;
+    tcp_nopush on;
+    tcp_nodelay on;
 
     keepalive_timeout  65;
 
-    #gzip  on;
+    gzip  on;
 
     server {
         listen       80 http2;

--- a/lambda/nginx/nginx.conf
+++ b/lambda/nginx/nginx.conf
@@ -27,6 +27,7 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
+    gzip_types    text/plain application/javascript application/x-javascript text/javascript text/xml text/css;
 
     server {
         listen       80 http2;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- enable gzip to get smaller assets sent over the wire
- enable nodelay and nopush https://thoughts.t37.net/nginx-optimization-understanding-sendfile-tcp-nodelay-and-tcp-nopush-c55cdd276765
- set proper gzip types https://stackoverflow.com/questions/23939722/nginx-gzip-not-compressing-javascript-files/23939813

**Related issue(s)**
See also kyma-project/kyma#144
