### PR TITLE
Support namespaced ServiceClasses in Service Catalog UI

### DIFF
--- a/catalog/src/components/Main/Main.component.js
+++ b/catalog/src/components/Main/Main.component.js
@@ -9,7 +9,7 @@ import { MainWrapper } from './styled';
 
 const MainPage = ({
   history,
-  clusterServiceClasses,
+  serviceClasses,
   filterClasses,
   filterClassesAndSetActiveFilters,
   filterFilters,
@@ -20,13 +20,21 @@ const MainPage = ({
   return (
     <ThemeWrapper>
       <MainWrapper>
-        {!clusterServiceClasses.loading && (
+        {!serviceClasses.loading && (
           <ServiceClassList
-            clusterServiceClasses={clusterServiceClasses.clusterServiceClasses}
+            serviceClasses={
+              !serviceClasses.error
+                ? [
+                    ...serviceClasses.clusterServiceClasses,
+                    ...serviceClasses.serviceClasses,
+                  ]
+                : []
+            }
             filterServiceClasses={filterClasses}
             setServiceClassesFilter={filterClassesAndSetActiveFilters}
             history={history}
             searchFn={searchFn}
+            errorMessage={serviceClasses.error && serviceClasses.error.message}
           />
         )}
       </MainWrapper>
@@ -36,7 +44,7 @@ const MainPage = ({
 
 MainPage.propTypes = {
   history: PropTypes.object.isRequired,
-  clusterServiceClasses: PropTypes.object.isRequired,
+  serviceClasses: PropTypes.object.isRequired,
   filterClasses: PropTypes.func.isRequired,
   filterClassesAndSetActiveFilters: PropTypes.func.isRequired,
 };

--- a/catalog/src/components/Main/Main.container.js
+++ b/catalog/src/components/Main/Main.container.js
@@ -7,18 +7,34 @@ import {
   SET_ACTIVE_FILTERS_MUTATION,
 } from './mutations';
 
+import builder from '../../commons/builder';
+
 import MainPage from './Main.component';
 
 export default compose(
   graphql(SERVICE_CLASSES_QUERY, {
-    name: 'clusterServiceClasses',
-    options: {
-      fetchPolicy: 'cache-and-network',
-      errorPolicy: 'all',
+    name: 'serviceClasses',
+    options: () => {
+      return {
+        variables: {
+          environment: builder.getCurrentEnvironmentId(),
+        },
+        options: {
+          fetchPolicy: 'cache-and-network',
+          errorPolicy: 'all',
+        },
+      };
     },
   }),
   graphql(FILTER_SERVICE_CLASS_MUTATION, {
     name: 'filterClasses',
+    options: () => {
+      return {
+        variables: {
+          environment: builder.getCurrentEnvironmentId(),
+        },
+      };
+    },
   }),
   graphql(SET_ACTIVE_FILTERS_MUTATION, {
     name: 'setActiveFilters',

--- a/catalog/src/components/Main/mutations.js
+++ b/catalog/src/components/Main/mutations.js
@@ -1,8 +1,8 @@
 import gql from 'graphql-tag';
 
 export const FILTER_SERVICE_CLASS_MUTATION = gql`
-  mutation filterServiceClasses {
-    filterServiceClasses @client
+  mutation filterServiceClasses($environment: String!) {
+    filterServiceClasses(environment: $environment) @client
   }
 `;
 

--- a/catalog/src/components/Main/queries.js
+++ b/catalog/src/components/Main/queries.js
@@ -1,16 +1,23 @@
 import gql from 'graphql-tag';
 
+const serviceClassesQGL = `
+  name
+  description
+  displayName
+  externalName
+  imageUrl
+  activated
+  providerDisplayName
+  tags
+`;
+
 export const SERVICE_CLASSES_QUERY = gql`
-  query clusterServiceClasses {
+  query serviceClasses($environment: String!) {
     clusterServiceClasses {
-      name
-      description
-      displayName
-      externalName
-      imageUrl
-      activated
-      providerDisplayName
-      tags
+      ${serviceClassesQGL}
+    }
+    serviceClasses(environment: $environment) {
+      ${serviceClassesQGL}
     }
   }
 `;

--- a/catalog/src/components/ServiceClassDetails/CreateInstanceModal/BasicData.component.js
+++ b/catalog/src/components/ServiceClassDetails/CreateInstanceModal/BasicData.component.js
@@ -18,9 +18,9 @@ class BasicData extends React.Component {
     data: PropTypes.object.isRequired,
     formData: PropTypes.object.isRequired,
     refetchInstanceExists: PropTypes.func.isRequired,
-    clusterServiceClass: PropTypes.object.isRequired,
-    clusterServiceClassExternalName: PropTypes.string.isRequired,
-    clusterServiceClassPlans: PropTypes.array,
+    serviceClass: PropTypes.object.isRequired,
+    serviceClassExternalName: PropTypes.string.isRequired,
+    serviceClassPlans: PropTypes.array,
   };
 
   constructor(props) {
@@ -31,30 +31,39 @@ class BasicData extends React.Component {
       invalidInstanceName: false,
       instanceWithNameAlreadyExists: false,
       stepFilled: props.data.stepFilled,
+      enableCheckNameExists: false,
     };
   }
 
-  componentWillMount() {
-    const { clusterServiceClass } = this.props;
+  async componentWillMount() {
+    const { serviceClass } = this.props;
     const { formData } = this.state;
 
-    if (!clusterServiceClass.clusterServiceClass) return;
+    if (!serviceClass) return;
 
-    const defaultInstanceName = `${
-      clusterServiceClass.clusterServiceClass.externalName
-    }-${randomNameGenerator()}`;
+    let defaultInstanceName = '';
+    while (true) {
+      defaultInstanceName = `${
+        serviceClass.externalName
+      }-${randomNameGenerator()}`;
 
-    this.setState({
-      formData: {
-        ...this.state.formData,
-        name: formData.name ? formData.name : defaultInstanceName,
-        plan: clusterServiceClass.clusterServiceClass.plans[0].name,
-      },
-    });
+      this.setState({
+        formData: {
+          ...formData,
+          name: defaultInstanceName,
+          plan: serviceClass.plans[0].name,
+        },
+      });
+
+      const { data, error } = await this.props.refetchInstanceExists(
+        defaultInstanceName,
+      );
+
+      if (!error && !data.serviceInstance) break;
+    }
   }
 
   componentDidMount() {
-    this.checkNameExists(this.state.formData.name);
     clearTimeout(this.timer);
   }
 
@@ -63,6 +72,7 @@ class BasicData extends React.Component {
       formData,
       invalidInstanceName,
       instanceWithNameAlreadyExists,
+      enableCheckNameExists,
     } = this.state;
 
     if (compareTwoObjects(this.state, nextState)) return;
@@ -89,6 +99,7 @@ class BasicData extends React.Component {
 
     clearTimeout(this.timer);
     if (
+      enableCheckNameExists &&
       !invalidInstanceName &&
       formData &&
       formData.name &&
@@ -106,6 +117,7 @@ class BasicData extends React.Component {
 
   onChangeName = value => {
     this.setState({
+      enableCheckNameExists: true,
       firstStepFilled: Boolean(value),
       instanceWithNameAlreadyExists: false,
       invalidInstanceName: this.validateInstanceName(value),
@@ -187,14 +199,14 @@ class BasicData extends React.Component {
   };
 
   render() {
-    const { clusterServiceClassPlans } = this.props;
+    const { serviceClassPlans } = this.props;
     const {
       formData,
       invalidInstanceName,
       instanceWithNameAlreadyExists,
     } = this.state;
 
-    const mappedPlans = clusterServiceClassPlans.map((p, i) => (
+    const mappedPlans = serviceClassPlans.map((p, i) => (
       <option key={['plan', i].join('_')} value={p.name}>
         {getResourceDisplayName(p)}
       </option>

--- a/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.container.js
+++ b/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.container.js
@@ -1,4 +1,5 @@
-import { graphql, compose } from 'react-apollo';
+import React from 'react';
+import { graphql, withApollo, compose } from 'react-apollo';
 
 import { CHECK_INSTANCE_EXISTS } from './queries';
 import { SEND_NOTIFICATION } from './mutations';
@@ -6,23 +7,25 @@ import { SEND_NOTIFICATION } from './mutations';
 import builder from '../../../commons/builder';
 import CreateInstanceModal from './CreateInstanceModal.component';
 
-export default compose(
-  graphql(CHECK_INSTANCE_EXISTS, {
-    options: props => {
-      return {
-        variables: {
-          name: props.defaultInstanceName,
-          environment: builder.getCurrentEnvironmentId(),
-        },
-        options: {
-          errorPolicy: 'all',
-        },
-        skip: true,
-      };
-    },
-    name: 'instanceExists',
-  }),
+const CreateInstanceContainer = ({ client, ...props }) => {
+  const instanceExists = name => {
+    return client.query({
+      query: CHECK_INSTANCE_EXISTS,
+      variables: {
+        name: name,
+        environment: builder.getCurrentEnvironmentId(),
+      },
+      fetchPolicy: 'network-only',
+      errorPolicy: 'all',
+    });
+  };
+  return <CreateInstanceModal instanceExists={instanceExists} {...props} />;
+};
+
+const CreateInstanceContainerWithCompose = compose(
   graphql(SEND_NOTIFICATION, {
     name: 'sendNotification',
   }),
-)(CreateInstanceModal);
+)(CreateInstanceContainer);
+
+export default withApollo(CreateInstanceContainerWithCompose);

--- a/catalog/src/components/ServiceClassDetails/ServiceClassDetails.component.js
+++ b/catalog/src/components/ServiceClassDetails/ServiceClassDetails.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button } from '@kyma-project/react-components';
+import { Button, Spinner } from '@kyma-project/react-components';
 
 import ServiceClassToolbar from './ServiceClassToolbar/ServiceClassToolbar.component';
 import ServiceClassInfo from './ServiceClassInfo/ServiceClassInfo.component';
@@ -13,27 +13,27 @@ import {
   ServiceClassDetailsWrapper,
   LeftSideWrapper,
   CenterSideWrapper,
+  EmptyList,
 } from './styled';
 
 import { getResourceDisplayName, getDescription } from '../../commons/helpers';
 
 class ServiceClassDetails extends React.Component {
   static propTypes = {
-    clusterServiceClass: PropTypes.object.isRequired,
+    serviceClass: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
     createServiceInstance: PropTypes.func.isRequired,
   };
 
   render() {
-    const { clusterServiceClass, history, createServiceInstance } = this.props;
+    const { history, createServiceInstance } = this.props;
+    const serviceClass =
+      this.props.serviceClass.clusterServiceClass ||
+      this.props.serviceClass.serviceClass;
 
-    const clusterServiceClassDisplayName = getResourceDisplayName(
-      clusterServiceClass.clusterServiceClass,
-    );
+    const serviceClassDisplayName = getResourceDisplayName(serviceClass);
 
-    const clusterServiceClassDescription = getDescription(
-      clusterServiceClass.clusterServiceClass,
-    );
+    const serviceClassDescription = getDescription(serviceClass);
 
     const modalOpeningComponent = (
       <Button normal primary first last microFullWidth data-e2e-id="add-to-env">
@@ -41,9 +41,22 @@ class ServiceClassDetails extends React.Component {
       </Button>
     );
 
+    if (this.props.serviceClass.loading) {
+      return (
+        <EmptyList>
+          <Spinner size="40px" color="#32363a" />
+        </EmptyList>
+      );
+    }
+    if (!this.props.serviceClass.loading && !serviceClass) {
+      return (
+        <EmptyList>Service Class doesn't exist in this environment</EmptyList>
+      );
+    }
+
     return (
       <div>
-        {clusterServiceClass.clusterServiceClass && (
+        {serviceClass && (
           <div>
             <div> {this.arrayOfJsx} </div>
             {this.renObjData}
@@ -51,10 +64,10 @@ class ServiceClassDetails extends React.Component {
               arrayOfJsx={this.arrayOfJsx}
               renObjData={this.renObjData}
               history={history}
-              clusterServiceClassDisplayName={clusterServiceClassDisplayName}
+              serviceClassDisplayName={serviceClassDisplayName}
             >
               <CreateInstanceModal
-                clusterServiceClass={clusterServiceClass}
+                serviceClass={serviceClass}
                 modalOpeningComponent={modalOpeningComponent}
                 createServiceInstance={createServiceInstance}
               />
@@ -63,32 +76,25 @@ class ServiceClassDetails extends React.Component {
             <ServiceClassDetailsWrapper phoneRows>
               <LeftSideWrapper>
                 <ServiceClassInfo
-                  clusterServiceClassDisplayName={
-                    clusterServiceClassDisplayName
-                  }
-                  providerDisplayName={
-                    clusterServiceClass.clusterServiceClass.providerDisplayName
-                  }
-                  creationTimestamp={
-                    clusterServiceClass.clusterServiceClass.creationTimestamp
-                  }
-                  documentationUrl={
-                    clusterServiceClass.clusterServiceClass.documentationUrl
-                  }
-                  supportUrl={
-                    clusterServiceClass.clusterServiceClass.supportUrl
-                  }
-                  imageUrl={clusterServiceClass.clusterServiceClass.imageUrl}
-                  tags={clusterServiceClass.clusterServiceClass.tags}
+                  serviceClassDisplayName={serviceClassDisplayName}
+                  providerDisplayName={serviceClass.providerDisplayName}
+                  creationTimestamp={serviceClass.creationTimestamp}
+                  documentationUrl={serviceClass.documentationUrl}
+                  supportUrl={serviceClass.supportUrl}
+                  imageUrl={serviceClass.imageUrl}
+                  tags={serviceClass.tags}
                 />
               </LeftSideWrapper>
               <CenterSideWrapper>
-                {clusterServiceClassDescription && (
+                {serviceClassDescription && (
                   <ServiceClassDescription
-                    description={clusterServiceClassDescription}
+                    description={serviceClassDescription}
                   />
                 )}
-                <ServiceClassTabs clusterServiceClass={clusterServiceClass} />
+                <ServiceClassTabs
+                  serviceClass={serviceClass}
+                  serviceClassLoading={this.props.serviceClass.loading}
+                />
               </CenterSideWrapper>
             </ServiceClassDetailsWrapper>
           </div>

--- a/catalog/src/components/ServiceClassDetails/ServiceClassDetails.container.js
+++ b/catalog/src/components/ServiceClassDetails/ServiceClassDetails.container.js
@@ -5,12 +5,15 @@ import { CREATE_SERVICE_INSTANCE } from './mutations';
 
 import ServiceClassDetails from './ServiceClassDetails.component';
 
+import builder from '../../commons/builder';
+
 export default compose(
   graphql(GET_SERVICE_CLASS, {
     options: props => {
       return {
         variables: {
           name: props.match.params.name,
+          environment: builder.getCurrentEnvironmentId(),
         },
         options: {
           fetchPolicy: 'cache-and-network',
@@ -18,7 +21,7 @@ export default compose(
         },
       };
     },
-    name: 'clusterServiceClass',
+    name: 'serviceClass',
   }),
   graphql(CREATE_SERVICE_INSTANCE, {
     name: 'createServiceInstance',

--- a/catalog/src/components/ServiceClassDetails/ServiceClassInfo/ServiceClassInfo.component.js
+++ b/catalog/src/components/ServiceClassDetails/ServiceClassInfo/ServiceClassInfo.component.js
@@ -16,7 +16,7 @@ import {
 } from './styled';
 
 const ServiceClassInfo = ({
-  clusterServiceClassDisplayName,
+  serviceClassDisplayName,
   providerDisplayName,
   creationTimestamp,
   documentationUrl,
@@ -36,7 +36,7 @@ const ServiceClassInfo = ({
         </ImagePlaceholder>
         <div>
           <ServiceTitle data-e2e-id="service-title">
-            {clusterServiceClassDisplayName}
+            {serviceClassDisplayName}
           </ServiceTitle>
           <ServiceProvider data-e2e-id="service-provider">
             {providerDisplayName || ''}
@@ -80,7 +80,7 @@ const ServiceClassInfo = ({
 };
 
 ServiceClassInfo.propTypes = {
-  clusterServiceClassDisplayName: PropTypes.string.isRequired,
+  serviceClassDisplayName: PropTypes.string.isRequired,
   providerDisplayName: PropTypes.string.isRequired,
   creationTimestamp: PropTypes.number,
   documentationUrl: PropTypes.string,

--- a/catalog/src/components/ServiceClassDetails/ServiceClassTabs/ServiceClassTabs.component.js
+++ b/catalog/src/components/ServiceClassDetails/ServiceClassTabs/ServiceClassTabs.component.js
@@ -14,16 +14,10 @@ import {
   validateAsyncApiSpec,
 } from '../../../commons/helpers';
 
-const ServiceClassTabs = ({ clusterServiceClass }) => {
-  const content =
-    clusterServiceClass.clusterServiceClass.content &&
-    clusterServiceClass.clusterServiceClass.content;
-  const apiSpec =
-    clusterServiceClass.clusterServiceClass.apiSpec &&
-    clusterServiceClass.clusterServiceClass.apiSpec;
-  const asyncApiSpec =
-    clusterServiceClass.clusterServiceClass.asyncApiSpec &&
-    clusterServiceClass.clusterServiceClass.asyncApiSpec;
+const ServiceClassTabs = ({ serviceClass, serviceClassLoading }) => {
+  const content = serviceClass.content && serviceClass.content;
+  const apiSpec = serviceClass.apiSpec && serviceClass.apiSpec;
+  const asyncApiSpec = serviceClass.asyncApiSpec && serviceClass.asyncApiSpec;
 
   if (
     (content && Object.keys(content).length && validateContent(content)) ||
@@ -35,7 +29,7 @@ const ServiceClassTabs = ({ clusterServiceClass }) => {
     let documentsByType = [],
       documentsTypes = [];
 
-    if (!clusterServiceClass.loading) {
+    if (!serviceClassLoading) {
       if (content && Object.keys(content).length) {
         documentsByType = sortDocumentsByType(content);
         documentsTypes = Object.keys(documentsByType);
@@ -100,7 +94,8 @@ const ServiceClassTabs = ({ clusterServiceClass }) => {
 };
 
 ServiceClassTabs.propTypes = {
-  clusterServiceClass: PropTypes.object.isRequired,
+  serviceClass: PropTypes.object.isRequired,
+  serviceClassLoading: PropTypes.bool.isRequired,
 };
 
 export default ServiceClassTabs;

--- a/catalog/src/components/ServiceClassDetails/ServiceClassToolbar/ServiceClassToolbar.component.js
+++ b/catalog/src/components/ServiceClassDetails/ServiceClassToolbar/ServiceClassToolbar.component.js
@@ -8,7 +8,7 @@ const ServiceClassToolbar = ({
   arrayOfJsx,
   renObjData,
   history,
-  clusterServiceClassDisplayName,
+  serviceClassDisplayName,
   children,
 }) => {
   const goToServiceInstanceList = () => {
@@ -24,7 +24,7 @@ const ServiceClassToolbar = ({
 
       <Toolbar
         back={goToServiceInstanceList}
-        headline={clusterServiceClassDisplayName}
+        headline={serviceClassDisplayName}
         addSeparator
       >
         {children}
@@ -36,7 +36,7 @@ const ServiceClassToolbar = ({
 ServiceClassToolbar.propTypes = {
   arrayOfJsx: PropTypes.any,
   renObjData: PropTypes.any,
-  clusterServiceClassDisplayName: PropTypes.string.isRequired,
+  serviceClassDisplayName: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
   history: PropTypes.object.isRequired,
 };

--- a/catalog/src/components/ServiceClassDetails/queries.js
+++ b/catalog/src/components/ServiceClassDetails/queries.js
@@ -1,28 +1,45 @@
 import gql from 'graphql-tag';
 
+const serviceClassQGL = `
+  name
+  externalName
+  displayName
+  creationTimestamp
+  description
+  longDescription
+  documentationUrl
+  supportUrl
+  imageUrl
+  providerDisplayName
+  tags
+  content
+  asyncApiSpec
+  apiSpec
+`;
+
+const plansQGL = `
+  name
+  instanceCreateParameterSchema
+  displayName
+  externalName
+`;
+
 export const GET_SERVICE_CLASS = gql`
-  query GetServiceClass($name: String!) {
+  query getServiceClass($name: String!, $environment: String!) {
     clusterServiceClass(name: $name) {
-      name
-      externalName
-      displayName
-      creationTimestamp
-      description
-      longDescription
-      documentationUrl
-      supportUrl
-      imageUrl
-      providerDisplayName
-      tags
-      content
-      asyncApiSpec
-      apiSpec
+      ${serviceClassQGL}
       plans {
-        name
-        instanceCreateParameterSchema
-        displayName
+        ${plansQGL}
         relatedClusterServiceClassName
-        externalName
+      }
+    }
+    serviceClass(name: $name, environment: $environment) {
+      ${serviceClassQGL}
+      environment
+      plans {
+        ${plansQGL}
+        environment
+        relatedServiceClassName
       }
     }
   }

--- a/catalog/src/components/ServiceClassDetails/styled.js
+++ b/catalog/src/components/ServiceClassDetails/styled.js
@@ -39,3 +39,12 @@ export const LeftSideWrapper = styled.div`
     flex: 1 1 100%;
   `};
 `;
+
+export const EmptyList = styled.div`
+  width: 100%;
+  font-family: '72';
+  text-align: center;
+  font-size: 20px;
+  color: #32363a;
+  margin: 50px 0;
+`;

--- a/catalog/src/components/ServiceClassList/ServiceClassList.component.js
+++ b/catalog/src/components/ServiceClassList/ServiceClassList.component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
+  NotificationMessage,
   Paragraph,
   Search,
   Spinner,
@@ -24,16 +25,17 @@ class ServiceClassList extends React.Component {
     activeClassFilters: PropTypes.object.isRequired,
     classList: PropTypes.object.isRequired,
     classFilters: PropTypes.object.isRequired,
-    clusterServiceClasses: PropTypes.array.isRequired,
+    serviceClasses: PropTypes.array.isRequired,
     history: PropTypes.object.isRequired,
     filterServiceClasses: PropTypes.func.isRequired,
     setServiceClassesFilter: PropTypes.func.isRequired,
+    errorMessage: PropTypes.string,
   };
 
   componentWillReceiveProps(newProps) {
     if (
-      newProps.clusterServiceClasses &&
-      newProps.clusterServiceClasses.length > 0 &&
+      newProps.serviceClasses &&
+      newProps.serviceClasses.length > 0 &&
       typeof newProps.filterServiceClasses === 'function'
     ) {
       newProps.filterServiceClasses();
@@ -50,6 +52,7 @@ class ServiceClassList extends React.Component {
       history,
       searchFn,
       filterTagsAndSetActiveFilters,
+      errorMessage,
     } = this.props;
 
     const filterFn = e =>
@@ -70,6 +73,18 @@ class ServiceClassList extends React.Component {
     items = items.filter(e => e.displayName || e.externalName || e.name);
 
     const renderCards = () => {
+      if (errorMessage) {
+        return (
+          <EmptyServiceListMessageWrapper>
+            <NotificationMessage
+              type="error"
+              title="Error"
+              message={errorMessage}
+            />
+          </EmptyServiceListMessageWrapper>
+        );
+      }
+
       if (items) {
         return items.length === 0 ? (
           <EmptyServiceListMessageWrapper>
@@ -102,9 +117,10 @@ class ServiceClassList extends React.Component {
               onChange={searchFn}
             />
           </SearchWrapper>
+
           {!classFilters.loading && (
             <FilterList
-              filters={classFilters.clusterServiceClassFilters}
+              filters={classFilters.serviceClassFilters}
               active={activeFilters}
               activeFiltersCount={activeFiltersCount}
               activeTagsFilters={activeCategoriesFilters}

--- a/catalog/src/components/ServiceClassList/ServiceClassList.container.js
+++ b/catalog/src/components/ServiceClassList/ServiceClassList.container.js
@@ -12,11 +12,20 @@ import { SET_ACTIVE_TAGS_FILTERS_MUTATION } from './mutations';
 
 import ServiceClassList from './ServiceClassList.component';
 
+import builder from '../../commons/builder';
+
 export default compose(
   graphql(FILTERED_CLASSES_QUERY, {
     name: 'classList',
-    options: {
-      fetchPolicy: 'cache-and-network',
+    options: () => {
+      return {
+        variables: {
+          environment: builder.getCurrentEnvironmentId(),
+        },
+        options: {
+          fetchPolicy: 'cache-and-network',
+        },
+      };
     },
   }),
   graphql(CLASS_ACTIVE_FILTERS_QUERY, {
@@ -27,8 +36,15 @@ export default compose(
   }),
   graphql(CLASS_FILTERS_QUERY, {
     name: 'classFilters',
-    options: {
-      fetchPolicy: 'cache-and-network',
+    options: () => {
+      return {
+        variables: {
+          environment: builder.getCurrentEnvironmentId(),
+        },
+        options: {
+          fetchPolicy: 'cache-and-network',
+        },
+      };
     },
   }),
 

--- a/catalog/src/components/ServiceClassList/queries.js
+++ b/catalog/src/components/ServiceClassList/queries.js
@@ -16,8 +16,8 @@ export const FILTERED_CLASSES_QUERY = gql`
 `;
 
 export const CLASS_FILTERS_QUERY = gql`
-  query clusterServiceClassFilters {
-    clusterServiceClassFilters @client {
+  query serviceClassFilters($environment: String!) {
+    serviceClassFilters(environment: $environment) @client {
       name
       isMore
       values @client {

--- a/catalog/src/store/Filter/defaults.js
+++ b/catalog/src/store/Filter/defaults.js
@@ -21,7 +21,7 @@ const defaults = {
     search: '',
     __typename: 'ActiveTagsFilters',
   },
-  clusterServiceClassFilters: [],
+  serviceClassFilters: [],
   filteredServiceClasses: [],
 };
 

--- a/catalog/src/store/MainPage/defaults.js
+++ b/catalog/src/store/MainPage/defaults.js
@@ -1,4 +1,5 @@
 const defaults = {
+  serviceClasses: [],
   clusterServiceClasses: [],
 };
 

--- a/catalog/src/store/ServiceClassDetails/defaults.js
+++ b/catalog/src/store/ServiceClassDetails/defaults.js
@@ -1,5 +1,5 @@
 const defaults = {
-  clusterServiceClass: {
+  serviceClass: {
     __typename: 'ServiceClass',
   },
 };

--- a/catalog/src/store/index.js
+++ b/catalog/src/store/index.js
@@ -12,7 +12,6 @@ export function createApolloClient() {
   );
 
   const client = new ApolloClient({
-    connectToDevTools: true,
     uri: graphqlApiUrl,
     request: async operation => {
       operation.setContext(({ headers = {} }) => ({

--- a/instances/src/components/ServiceInstanceDetails/queries.js
+++ b/instances/src/components/ServiceInstanceDetails/queries.js
@@ -1,5 +1,25 @@
 import gql from 'graphql-tag';
 
+const serviceClassQGL = `
+  name
+  displayName
+  externalName
+  description
+  documentationUrl
+  supportUrl
+  content
+  asyncApiSpec
+  apiSpec
+`;
+
+const servicePlanQGL = `
+  name
+  displayName
+  externalName
+  description
+  instanceCreateParameterSchema
+`;
+
 export const SERVICE_INSTANCE_QUERY = gql`
   query ServiceInstance($environment: String!, $name: String!) {
     serviceInstance(environment: $environment, name: $name) {
@@ -12,44 +32,20 @@ export const SERVICE_INSTANCE_QUERY = gql`
         message
       }
       serviceClass {
-        name
+        ${serviceClassQGL}
         environment
-        displayName
-        externalName
-        description
-        documentationUrl
-        supportUrl
-        content
-        asyncApiSpec
-        apiSpec
       }
       clusterServiceClass {
-        name
-        displayName
-        externalName
-        description
-        documentationUrl
-        supportUrl
-        content
-        asyncApiSpec
-        apiSpec
+        ${serviceClassQGL}
       }
       servicePlan {
-        name
+        ${servicePlanQGL}
         environment
-        displayName
-        externalName
         relatedServiceClassName
-        description
-        instanceCreateParameterSchema
       }
       clusterServicePlan {
-        name
-        displayName
-        externalName
+        ${servicePlanQGL}
         relatedClusterServiceClassName
-        description
-        instanceCreateParameterSchema
       }
       serviceBindings {
         serviceBindings {

--- a/instances/src/components/ServiceInstances/ServiceInstancesTable/ServiceInstancesTable.component.js
+++ b/instances/src/components/ServiceInstances/ServiceInstancesTable/ServiceInstancesTable.component.js
@@ -14,7 +14,7 @@ import {
   LinkButton,
   Link,
   ServiceClassButton,
-  AddServiceRedirectButton,
+  AddServiceInstanceRedirectButton,
   ServicePlanButton,
   JSONCode,
 } from './styled';
@@ -74,10 +74,10 @@ function ServiceInstancesTable({
     </div>
   );
 
-  const addServiceRedirectButton = (
-    <AddServiceRedirectButton onClick={goToServiceCatalog}>
-      + Add Service
-    </AddServiceRedirectButton>
+  const addServiceInstanceRedirectButton = (
+    <AddServiceInstanceRedirectButton onClick={goToServiceCatalog}>
+      + Add Instance
+    </AddServiceInstanceRedirectButton>
   );
 
   const table = {
@@ -196,7 +196,7 @@ function ServiceInstancesTable({
   return (
     <Table
       title={table.title}
-      addHeaderContent={addServiceRedirectButton}
+      addHeaderContent={addServiceInstanceRedirectButton}
       columns={table.columns}
       data={table.data}
       loading={loading}

--- a/instances/src/components/ServiceInstances/ServiceInstancesTable/styled.js
+++ b/instances/src/components/ServiceInstances/ServiceInstancesTable/styled.js
@@ -17,7 +17,7 @@ export const ServiceClassButton = styled.span`
   cursor: pointer;
 `;
 
-export const AddServiceRedirectButton = styled.button`
+export const AddServiceInstanceRedirectButton = styled.button`
   padding: 0;
   background: none;
   border: 0;

--- a/instances/src/components/ServiceInstances/queries.js
+++ b/instances/src/components/ServiceInstances/queries.js
@@ -1,5 +1,17 @@
 import gql from 'graphql-tag';
 
+const serviceClassQGL = `
+  displayName
+  externalName
+  name
+`;
+
+const servicePlanQGL = `
+  displayName
+  externalName
+  name
+`;
+
 export const SERVICE_INSTANCES_QUERY = gql`
   query ServiceInstances($environment: String!) {
     serviceInstances(environment: $environment) {
@@ -11,24 +23,16 @@ export const SERVICE_INSTANCES_QUERY = gql`
         message
       }
       serviceClass {
-        displayName
-        externalName
-        name
+        ${serviceClassQGL}
       }
       clusterServiceClass {
-        displayName
-        externalName
-        name
+        ${serviceClassQGL}
       }
       servicePlan {
-        displayName
-        externalName
-        name
+        ${servicePlanQGL}
       }
       clusterServicePlan {
-        displayName
-        externalName
-        name
+        ${servicePlanQGL}
       }
       serviceBindingUsages {
         name
@@ -69,24 +73,10 @@ export const FILTERED_ITEMS_QUERY = gql`
         message
       }
       serviceClass {
-        displayName
-        externalName
-        name
-      }
-      clusterServiceClass {
-        displayName
-        externalName
-        name
+        ${serviceClassQGL}
       }
       servicePlan {
-        displayName
-        externalName
-        name
-      }
-      clusterServicePlan {
-        displayName
-        externalName
-        name
+        ${servicePlanQGL}
       }
     }
   }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Fix bug with additional calls to query `serviceInstance` in `service catalog` (#150),
- Add possibility to provisioning `ServiceClass` (at the moment, user only can provisioning `ClusterServiceClass`) (#182),
- Add possibility to filter by `providerName`, `className` and `status` of instance in `instances list` view (#182).

**How to enable namespaced service broker**
- run `kubectl edit deployment -n kyma-system core-catalog-controller-manager` and change version of image to `0.1.33-fix-namespaced`,
- run `kubectl edit deployment -n kyma-system core-remote-environment-broker` and change `APP_CLUSTER_SCOPED_BROKER_ENABLED` to `false`
- go to `kyma/components/remote-environment-broker/contrib/examples` and run `kubectl apply -f remote-env.yaml` and then `kubectl apply -f mapping.yaml -n production`

**Related issue(s)**
See also #150 
See also #182 