### PR TITLE
Test removed due to removal of default remote environments (#1458)

### DIFF
--- a/tests/ui-tests/tests/console-basic-test.js
+++ b/tests/ui-tests/tests/console-basic-test.js
@@ -89,6 +89,15 @@ describeIf(dex.isStaticUser(), 'Console basic tests', () => {
     expect(environments).not.toContain(config.testEnv);
   });
 
+  test('Check if remote environment exist', async () => {
+    common.validateTestEnvironment(dexReady);
+    const remoteEnvironmentsUrl = address.console.getRemoteEnvironments();
+    await page.goto(remoteEnvironmentsUrl, { waitUntil: 'networkidle0' });
+    const remoteEnvironments = await kymaConsole.getRemoteEnvironments(page);
+    console.log('Check if remote environment exists', remoteEnvironments);
+    expect(remoteEnvironments).not.toContain(config.testEnv);
+  });
+
   test('Create remote environment', async () => {
     common.validateTestEnvironment(dexReady);
     await kymaConsole.createRemoteEnvironment(page, config.testEnv);

--- a/tests/ui-tests/tests/console-basic-test.js
+++ b/tests/ui-tests/tests/console-basic-test.js
@@ -89,16 +89,6 @@ describeIf(dex.isStaticUser(), 'Console basic tests', () => {
     expect(environments).not.toContain(config.testEnv);
   });
 
-  test('Check if remote environment exist', async () => {
-    common.validateTestEnvironment(dexReady);
-    const remoteEnvironmentsUrl = address.console.getRemoteEnvironments();
-    await page.goto(remoteEnvironmentsUrl, { waitUntil: 'networkidle0' });
-    const remoteEnvironments = await kymaConsole.getRemoteEnvironments(page);
-    console.log('Check if remote environment exists', remoteEnvironments);
-    expect(remoteEnvironments.length).toBeGreaterThan(0);
-    expect(remoteEnvironments).not.toContain(config.testEnv);
-  });
-
   test('Create remote environment', async () => {
     common.validateTestEnvironment(dexReady);
     await kymaConsole.createRemoteEnvironment(page, config.testEnv);


### PR DESCRIPTION
**Description**

Test `check if remote enviroment exists` has been removed because it checks default remote environments which are no longer deployed.

**Related issue(s)**
#1458