### PR TITLE
Enable default size for functions and add Horizontal Pod Autoscaling …

### DIFF
--- a/lambda/src/app/app.config.ts
+++ b/lambda/src/app/app.config.ts
@@ -7,6 +7,59 @@ if (clusterConfig && clusterConfig['domain']) {
   domain = clusterConfig['domain'];
 }
 
+const defaultFunctionSizesConf = {
+  hpaCpuTargetAverageUtilization: 40,
+  functionResources: { requests: { cpu: '100m', memory: '100Mi' } },
+  functionSizes: [
+    {
+      size: {
+        name: 'S',
+        memory: '128Mi',
+        cpu: '100m',
+        minReplicas: 1,
+        maxReplicas: 2,
+        description: '',
+      },
+    },
+    {
+      size: {
+        name: 'M',
+        memory: '256Mi',
+        cpu: '500m',
+        minReplicas: 2,
+        maxReplicas: 5,
+        description: '',
+      },
+    },
+    {
+      size: {
+        name: 'L',
+        memory: '512Mi',
+        cpu: '1.0',
+        minReplicas: 5,
+        maxReplicas: 10,
+        description: '',
+      },
+    },
+  ],
+};
+
+let functionSizes = defaultFunctionSizesConf['functionSizes'];
+if (clusterConfig && clusterConfig['functionSizes']) {
+  functionSizes = clusterConfig['functionSizes'];
+}
+
+let functionResourceRequest = defaultFunctionSizesConf['functionResources'];
+if (clusterConfig && clusterConfig['functionResources']) {
+  functionResourceRequest = clusterConfig['functionResources'];
+}
+
+let targetAverageUtilization =
+  defaultFunctionSizesConf['hpaCpuTargetAverageUtilization'];
+if (clusterConfig && clusterConfig['hpaCpuTargetAverageUtilization']) {
+  targetAverageUtilization = clusterConfig['hpaCpuTargetAverageUtilization'];
+}
+
 const k8sServerUrl = `https://apiserver.${domain}`;
 
 const config = {
@@ -20,7 +73,11 @@ const config = {
   serviceCatalogApiUrl: `${k8sServerUrl}/apis/servicecatalog.k8s.io/v1beta1`,
   subscriptionApiUrl: `${k8sServerUrl}/apis/eventing.kyma.cx/v1alpha1`,
   graphqlApiUrl: `https://ui-api.${domain}/graphql`,
+  autoscalingUrl: `${k8sServerUrl}/apis/autoscaling/v1`,
   domain,
+  functionSizes,
+  functionResourceRequest,
+  targetAverageUtilization,
 };
 
 if (clusterConfig) {

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.html
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.html
@@ -24,7 +24,7 @@
           <div class="tn-form__item">
             <label class="tn-form__label" for="input-1">Function Name *</label>
             <input class="tn-form__control" type="text" id="input-1" [(ngModel)]="lambda.metadata.name" [attr.disabled]="mode==='create'?null:''"
-              (keyup)="validatesName()">
+                   (keyup)="validatesName()">
             <div *ngIf="isFunctionNameInvalid">
               <p class="alert">Invalid name: must consist of lower case alphanumeric characters, '-' or '.', no spaces
                 and must start and
@@ -37,15 +37,15 @@
             <label class="tn-form__label" for="input-2">Labels</label>
             <div class="labels-input" id="input-2">
               <span title="Edit label" class="tn-badge-labels tn-badge tn-badge--pill labels" *ngFor="let label of labels"
-                (click)="updateLabel(label)">
+                    (click)="updateLabel(label)">
                 {{ label }}
-                <div class="tn-icon tn-icon--remove remove-btn labels__remove" (click)="removeLabel(label)"></div>
+                  <div class="tn-icon tn-icon--remove remove-btn labels__remove" (click)="removeLabel(label)"></div>
               </span>
               <input #labelsInput type="text" [(ngModel)]="newLabel" (keydown.enter)="addLabel()" (keydown.tab)="addLabel()"
-                [attr.disabled]="(!lambda.metadata.name || isFunctionNameInvalid) ? '':null" (blur)="addLabel()">
+                     [attr.disabled]="(!lambda.metadata.name || isFunctionNameInvalid) ? '':null" (blur)="addLabel()">
             </div>
             <div *ngIf="wrongLabel" class="alert alert-danger">
-              {{ wrongLabelMessage }}
+            {{ wrongLabelMessage }}
             </div>
           </div>
         </div>
@@ -65,19 +65,19 @@
             <div class="sf-toolbar__item sf-trigger-list-elements">
               <div [ngClass]="selectedTriggers.length > 0 ? 'lambda-editor-header-list' : 'lambda-editor-header-list-first-elem'">
                 <button class="tn-button tn-button--small tn-button--text" (click)="toggleTriggerTypeDropdown($event)"
-                  dropdown="triggerType" [disabled]="!lambda.metadata.name || isFunctionNameInvalid">Select Function
+                        dropdown="triggerType" [disabled]="!lambda.metadata.name || isFunctionNameInvalid">Select Function
                   Trigger</button>
                 <div (mouseleave)="closeTriggerTypeDropDown()">
                   <div class="tn-dropdown__menu trigger-menu" [attr.aria-hidden]="!toggleTriggerType">
                     <ul class="tn-dropdown__menu trigger-menu">
                       <li>
                         <a [class.disabled]="lambda.metadata.name.length <=0 || isFunctionNameInvalid" (click)="showEventTrigger()"
-                          class="tn-dropdown__item">Event Trigger</a>
+                           class="tn-dropdown__item">Event Trigger</a>
                       </li>
 
                       <li>
                         <a [class.disabled]="lambda.metadata.name.length <= 0 || isFunctionNameInvalid || isHTTPTriggerAdded"
-                          (click)="showHTTPTrigger()" class="tn-dropdown__item">Expose via HTTPS</a>
+                           (click)="showHTTPTrigger()" class="tn-dropdown__item">Expose via HTTPS</a>
                       </li>
                     </ul>
                   </div>
@@ -98,13 +98,13 @@
                     <ng-container *ngIf="trigger.eventType!=='http'">- {{ trigger.version }} </ng-container>
 
                     <div clickOutsideEvents="click" (clickOutside)="hideHTTPURL()" [exclude]="'.tn-badge--pill'"
-                      excludeBeforeClick="true" class="tn-dropdown__menu trigger-menu" *ngIf="showHTTPURL == trigger">
+                         excludeBeforeClick="true" class="tn-dropdown__menu trigger-menu" *ngIf="showHTTPURL == trigger">
                       <div class="trigger-body">
                         https://{{ httpURL }}/
                       </div>
                       <div class="trigger-footer">
                         <button *ngIf="isHTTPTriggerAuthenticated" class="tn-button tn-button--small tn-button--text"
-                          (click)=showFetchTokenModal()>
+                                (click)=showFetchTokenModal()>
                           Fetch Token
                         </button>
                         <button class="tn-button tn-button--small tn-button--text" (click)=copyHTTPURLEndpoint($event)>
@@ -118,15 +118,29 @@
             </div>
             <div class="sf-toolbar__item sf-toolbar__right sf-typeselect">
               <div class="tn-form__group sf-dropdown__lambda-type">
+                <label class="tn-form__label">Size: </label>
+                <div class="tn-dropdown" (mouseleave)="closeSizeDropDown()">
+                  <button class="tn-dropdown__control" aria-controls="nNJnB2719" aria-expanded="false" aria-haspopup="true"
+                          (click)="toggleSizeDropDown()" [disabled]="!lambda.metadata.name || isFunctionNameInvalid">
+                  {{ selectedFunctionSizeName }}
+                  </button>
+                  <div class="tn-dropdown__menu text-left" [attr.aria-hidden]="sizeDropdownHidden">
+                    <div class="tn-dropdown__item" *ngFor="let item of functionSizes" (click)="selectSize(item)">
+                    <div>{{ item.name }}</div><br><div>{{ item.description }}</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="tn-form__group sf-dropdown__lambda-type">
                 <label class="tn-form__label">Type: </label>
                 <div class="tn-dropdown" (mouseleave)="closeTypeDropDown()">
-                  <button class="tn-dropdown__control" aria-controls="nNJnB279" aria-expanded="false" aria-haspopup="true"
-                    (click)="toggleTypeDropDown()" [disabled]="!lambda.metadata.name || isFunctionNameInvalid">
-                    {{ kind }}
+                  <button class="tn-dropdown__control" aria-controls="nNJnB279" aria-expanded="false" aria-haspopup="true" (click)="toggleTypeDropDown()"
+                          [disabled]="!lambda.metadata.name || isFunctionNameInvalid">
+                  {{ kind }}
                   </button>
                   <div class="tn-dropdown__menu text-left" [attr.aria-hidden]="typeDropdownHidden">
                     <div class="tn-dropdown__item" *ngFor="let type of types" (click)="selectType(type)">
-                      {{ type.kind }}
+                    {{ type.kind }}
                     </div>
                   </div>
                 </div>
@@ -145,7 +159,7 @@
     <div class="tn-form__item">
       <div class="sf-toolbar">
         <button *ngIf="(hasDependencies | async) === false" class="tn-button tn-button--small tn-button--stroked"
-          (click)="addDependencies()" [disabled]="!lambda.metadata.name || isFunctionNameInvalid">
+                (click)="addDependencies()" [disabled]="!lambda.metadata.name || isFunctionNameInvalid">
           + Add Dependencies
         </button>
         <div class="sf-toolbar__item" *ngIf="(hasDependencies | async)">
@@ -156,7 +170,7 @@
         <div class="sf-toolbar__right">
           <div class="sf-toolbar__item">
             <button *ngIf="(hasDependencies | async)" class="tn-button sf-button--danger tn-button--small tn-button--text"
-              (click)="removeDependencies()">
+                    (click)="removeDependencies()">
               Remove
             </button>
           </div>
@@ -174,12 +188,12 @@
 
 <section class="sf-panel" *ngIf="loaded | async">
   <app-lambda-instance-bindings [lambdaName]="lambda.metadata.name" [isLambdaNameInvalid]="isFunctionNameInvalid"
-    (bindingStateEmitter)="handleBindingStateEmitter($event)"></app-lambda-instance-bindings>
+                                (bindingStateEmitter)="handleBindingStateEmitter($event)"></app-lambda-instance-bindings>
 </section>
 
 <section class="sf-panel" *ngIf="loaded | async">
   <app-lambda-env-table [envs]="lambda.spec.deployment.spec.template.spec.containers[0].env" [lambdaName]="lambda.metadata.name"
-    [isLambdaNameInvalid]="isFunctionNameInvalid" (envEmitter)="handleEnvEmitter($event)"></app-lambda-env-table>
+                        [isLambdaNameInvalid]="isFunctionNameInvalid" (envEmitter)="handleEnvEmitter($event)"></app-lambda-env-table>
 
 </section>
 <app-fetch-token-modal #fetchTokenModal></app-fetch-token-modal>

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.scss
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.scss
@@ -41,6 +41,16 @@ $hover: #008ac6;
   }
 }
 
+.sf-toolbar__right {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    margin-left: auto !important;
+    font-size: 1rem;
+    color: #21262c;
+    padding: 0.8em 2em 0.8em 2em;
+}
+
 .sf-trigger-list-elements {
   grid-column-start: 1;
 }
@@ -327,6 +337,8 @@ $hover: #008ac6;
 
 .sf-dropdown__lambda-type {
   margin-bottom: 0;
+  margin-right: 40px;
+  padding-right: 60px;
   &:before {
     content: '';
     width: 1px;

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
@@ -72,6 +72,7 @@ export class LambdaDetailsComponent implements AfterViewInit {
       kind: 'nodejs8',
     },
   ];
+
   theme: string;
   @ViewChild('fetchTokenModal') fetchTokenModal: FetchTokenModalComponent;
   @ViewChild('eventTriggerChooserModal')
@@ -85,14 +86,18 @@ export class LambdaDetailsComponent implements AfterViewInit {
   mode = 'create';
   title = '';
   kind: string;
+  selectedFunctionSize: object;
+  selectedFunctionSizeName: string;
   showSample = false;
   toggleTrigger = false;
   toggleTriggerType = false;
   typeDropdownHidden = true;
+  sizeDropdownHidden = true;
   isLambdaFormValid = true;
   showHTTPURL: HTTPEndpoint = null;
   httpURL = '';
   labels = [];
+  annotations = [];
   md: IMetaData = {
     name: '',
   };
@@ -114,6 +119,7 @@ export class LambdaDetailsComponent implements AfterViewInit {
   existingHTTPEndpoint: Api;
   bindingState: Map<string, InstanceBindingState>;
   sessionId: string;
+  functionSizes = [];
 
   public issuer: string;
   public jwksUri: string;
@@ -133,6 +139,16 @@ export class LambdaDetailsComponent implements AfterViewInit {
     protected route: ActivatedRoute,
     router: Router,
   ) {
+    this.functionSizes = AppConfig.functionSizes.map(s => s['size']).map(s => {
+      s.description = `Memory: ${s.memory} CPU: ${s.cpu} minReplicas: ${
+        s.minReplicas
+      } maxReplicas: ${s.maxReplicas}`;
+      return s;
+    });
+
+    this.selectedFunctionSize = this.functionSizes[0];
+    this.selectedFunctionSizeName = this.selectedFunctionSize['name'];
+
     this.theme = 'eclipse';
     this.aceMode = 'javascript';
     this.aceDependencyMode = 'json';
@@ -221,6 +237,12 @@ export class LambdaDetailsComponent implements AfterViewInit {
     this.typeDropdownHidden = true;
   }
 
+  selectSize(selectedSize) {
+    this.selectedFunctionSize = selectedSize;
+    this.selectedFunctionSizeName = this.selectedFunctionSize['name'];
+    this.sizeDropdownHidden = true;
+  }
+
   onCodeChange(event) {
     const isChange = this.lambda.spec.function !== event;
     this.lambda.spec.function = event;
@@ -275,6 +297,27 @@ export class LambdaDetailsComponent implements AfterViewInit {
         ? this.selectedTriggers[0].eventType
         : 'undefined';
     this.setChecksum();
+
+    if (this.functionSizeHasChanged() === true) {
+      this.lambdaDetailsService.deleteHPA(this.lambda, this.token).subscribe(
+        hpa => {
+          this.setFunctionSize();
+          this.lambda.metadata.annotations = {
+            'function-size': `${this.selectedFunctionSize['name']}`,
+          };
+          this.handleFunctionUpdate();
+        },
+        err => {
+          console.log(err);
+          this.error = err.message;
+        },
+      );
+    } else {
+      this.handleFunctionUpdate();
+    }
+  }
+
+  handleFunctionUpdate() {
     this.lambdaDetailsService.updateLambda(this.lambda, this.token).subscribe(
       lambda => {
         if (this.isHTTPTriggerAdded) {
@@ -662,7 +705,13 @@ export class LambdaDetailsComponent implements AfterViewInit {
       'created-by': 'kubeless',
       function: this.lambda.metadata.name,
     };
+    this.lambda.metadata.annotations = {
+      'function-size': `${this.selectedFunctionSize['name']}`,
+    };
+
     this.lambda.metadata.labels = this.changeLabels();
+
+    this.setFunctionSize();
 
     this.lambdaDetailsService.createLambda(this.lambda, this.token).subscribe(
       lambda => {
@@ -674,6 +723,7 @@ export class LambdaDetailsComponent implements AfterViewInit {
         }
       },
       err => {
+        console.log(err);
         this.error = err.message;
       },
     );
@@ -699,8 +749,16 @@ export class LambdaDetailsComponent implements AfterViewInit {
     this.typeDropdownHidden = !this.typeDropdownHidden;
   }
 
+  toggleSizeDropDown() {
+    this.sizeDropdownHidden = !this.sizeDropdownHidden;
+  }
+
   closeTypeDropDown() {
     return (this.typeDropdownHidden = true);
+  }
+
+  closeSizeDropDown() {
+    return (this.sizeDropdownHidden = true);
   }
 
   closeTriggerTypeDropDown() {
@@ -727,6 +785,7 @@ export class LambdaDetailsComponent implements AfterViewInit {
         lambda => {
           this.lambda = lambda;
           this.labels = this.getLabels(lambda);
+          this.annotations = this.getAnnotations(lambda);
           this.code = lambda.spec.function;
           this.kind = lambda.spec.runtime;
           this.dependency = lambda.spec.deps;
@@ -735,7 +794,14 @@ export class LambdaDetailsComponent implements AfterViewInit {
               this.dependency !== undefined &&
               this.dependency !== '',
           );
+
           this.loaded = observableOf(true);
+          this.functionSizes.forEach(s => {
+            if (`${s.name}` === lambda.metadata.annotations['function-size']) {
+              this.selectedFunctionSize = s;
+              this.selectedFunctionSizeName = this.selectedFunctionSize['name'];
+            }
+          });
         },
         err => {
           this.navigateToList();
@@ -755,6 +821,20 @@ export class LambdaDetailsComponent implements AfterViewInit {
       }
     }
     return labels;
+  }
+
+  getAnnotations(lambda): string[] {
+    const annotations = [];
+    for (const key in lambda.metadata.annotations) {
+      if (lambda.metadata.annotations.hasOwnProperty(key)) {
+        if (lambda.metadata.annotations[key] === 'undefined') {
+          annotations.push(key);
+        } else {
+          annotations.push(key + ':' + lambda.metadata.annotations[key]);
+        }
+      }
+    }
+    return annotations;
   }
 
   cancel() {
@@ -1093,5 +1173,60 @@ export class LambdaDetailsComponent implements AfterViewInit {
       { msg: 'luigi.set-page-dirty', dirty: hasChanges },
       '*',
     );
+  }
+
+  setFunctionSize() {
+    const resources = {
+      limits: {
+        cpu: this.selectedFunctionSize['cpu'],
+        memory: this.selectedFunctionSize['memory'],
+      },
+      requests: AppConfig.functionResourceRequest.requests,
+    };
+
+    // Function Size
+    this.lambda.spec.deployment.spec.replicas = this.selectedFunctionSize[
+      'minReplicas'
+    ];
+    this.lambda.spec.deployment.spec.template.spec.containers[0].name = this.lambda.metadata.name;
+    this.lambda.spec.deployment.spec.template.spec.containers[0].resources = resources;
+
+    // Autoscaler
+    this.lambda.spec.horizontalPodAutoscaler.metadata.name = `${
+      this.lambda.metadata.name
+    }`;
+    this.lambda.spec.horizontalPodAutoscaler.metadata.namespace = this.environment;
+    this.lambda.spec.horizontalPodAutoscaler.metadata.labels = {
+      function: `${this.lambda.metadata.name}`,
+    };
+
+    this.lambda.spec.horizontalPodAutoscaler.spec.scaleTargetRef.name = this.lambda.metadata.name;
+
+    // horizontalPodAutoscaler -> spec -> minReplicas and maxReplicas
+    this.lambda.spec.horizontalPodAutoscaler.spec.minReplicas = this.selectedFunctionSize[
+      'minReplicas'
+    ];
+    this.lambda.spec.horizontalPodAutoscaler.spec.maxReplicas = this.selectedFunctionSize[
+      'maxReplicas'
+    ];
+
+    // cpu: spec -> metrics -> resource -> targetAverageUtilization
+    this.lambda.spec.horizontalPodAutoscaler.spec.metrics[0].resource.targetAverageUtilization =
+      AppConfig.targetAverageUtilization;
+  }
+
+  functionSizeHasChanged(): boolean {
+    let functionSizeChanged = false;
+    if (this.annotations.length > 0) {
+      this.annotations.forEach(label => {
+        const annotationsSplitted = label.split(':');
+        if (annotationsSplitted[0] === 'function-size') {
+          if (annotationsSplitted[1] !== this.selectedFunctionSize['name']) {
+            functionSizeChanged = true;
+          }
+        }
+      });
+      return functionSizeChanged;
+    }
   }
 }

--- a/lambda/src/app/shared/datamodel/k8s/autoscaler.ts
+++ b/lambda/src/app/shared/datamodel/k8s/autoscaler.ts
@@ -1,0 +1,37 @@
+import { IMetaDataOwner, MetaDataOwner } from './generic/meta-data-owner';
+
+export interface IHPAutoscaler extends IMetaDataOwner {
+  spec: IHPAutoscalerSpec;
+}
+
+export interface IHPAutoscalerSpec {
+  scaleTargetRef: IScaleTargetRef;
+  maxReplicas: number;
+  minReplicas: number;
+  metrics: IMetricSpec[];
+}
+
+export interface IScaleTargetRef {
+  apiVersion: string;
+  kind: string;
+  name: string;
+}
+
+export interface IMetricResource {
+  name: string;
+  targetAverageUtilization: number;
+}
+
+export interface IMetricSpec {
+  type: string;
+  resource: IMetricResource;
+}
+
+export class HPAutoscaler extends MetaDataOwner implements IHPAutoscaler {
+  spec: IHPAutoscalerSpec;
+
+  constructor(input: IHPAutoscaler) {
+    super(input.metadata, input.status);
+    this.spec = input.spec;
+  }
+}

--- a/lambda/src/app/shared/datamodel/k8s/function.ts
+++ b/lambda/src/app/shared/datamodel/k8s/function.ts
@@ -3,6 +3,7 @@ import { Deployment, IDeployment, IDeploymentStatus } from './deployment';
 import { Service, IServiceSpec } from './service';
 import { IMetaDataOwner, MetaDataOwner } from './generic/meta-data-owner';
 import { IPodTemplate } from './pod-template';
+import { HPAutoscaler, IHPAutoscaler } from './autoscaler';
 
 export interface IFunction extends IMetaDataOwner {
   spec?: IFunctionSpec;
@@ -20,7 +21,7 @@ export interface IFunctionSpec {
   deps: string;
   service: IServiceSpec;
   deployment: IDeployment;
-  // horizontalPodAutoscaler HorizontalPodAutoscaler;
+  horizontalPodAutoscaler?: IHPAutoscaler;
 }
 
 export class Lambda extends MetaDataOwner implements IFunction {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

* The size of a function can be defined while the function is either created or updated.
* Horizontal Pod Autoscaler is part of the deployment.
* Initial set of values for function size such as resources (limits and requests) and hpa (minReplicas, maxReplicas and targetAverageUtilization)  are readed fron cluster config.

**Related issue(s)**
- https://github.com/kyma-project/kyma/issues/716

**Related PR(s)**
- https://github.com/kyma-project/kyma/pull/1672