### PR TITLE
Enable in Lambda UI the deletion of ServiceBindings created either in…

### DIFF
--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
@@ -471,18 +471,30 @@ export class LambdaDetailsComponent implements AfterViewInit {
 
     deleteBindingStates.forEach(bs => {
       this.serviceBindingUsagesService
-        .getServiceBindingUsages(this.environment, this.token, {
-          labelSelector: `Function=${
-            this.lambda.metadata.name
-          }, ServiceBinding=${bs.previousState.serviceBinding}`,
-        })
+        .getServiceBindingUsages(this.environment, this.token, {})
         .subscribe(bsuList => {
           bsuList.items.forEach(bsu => {
-            if (bs.previousState.serviceBinding === bsu.metadata.name) {
+            if (
+              bs.previousState.serviceBinding ===
+              bsu.spec.serviceBindingRef.name
+            ) {
               deleteRequests.push(
                 this.serviceBindingUsagesService
                   .deleteServiceBindingUsage(
                     bsu.metadata.name,
+                    this.environment,
+                    this.token,
+                  )
+                  .pipe(
+                    catchError(err => {
+                      return observableOf(err);
+                    }),
+                  ),
+              );
+              deleteRequests.push(
+                this.serviceBindingsService
+                  .deleteServiceBinding(
+                    bs.previousState.serviceBinding,
                     this.environment,
                     this.token,
                   )


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Delete in Lambda UI ServiceBinding created  via Lambda UI with selected select existing secret for binding.
- Delete in Lambda UI a ServiceBinding created via ServiceCatalog.

**Related issue(s)**
[See also #1546](https://github.com/kyma-project/kyma/issues/1546)
