### PR TITLE
Cannot configure title, logo and favicon in luigified console

### DIFF
--- a/core/src/assets/luigi-config.js
+++ b/core/src/assets/luigi-config.js
@@ -611,8 +611,17 @@ Luigi.setConfig({
     skipRoutingForUrlPatterns: [/access_token=/, /id_token=/]
   },
   settings: {
-    header: () => ({
-      logo: '/assets/logo.svg'
-    })
+    header: () => {
+      logo = clusterConfig.headerLogoUrl
+        ? clusterConfig.headerLogoUrl
+        : '/assets/logo.svg';
+      title = clusterConfig.headerTitle;
+      favicon = clusterConfig.faviconUrl;
+      return {
+        logo,
+        title,
+        favicon
+      };
+    }
   }
 });


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Pass the console configuration around title, logo and favicon to the luigi configuration

**Related issue(s)**
https://github.com/kyma-project/console/issues/480
