### PR TITLE
Fix promise synchronisation in ui tests

### DIFF
--- a/tests/ui-tests/commands/console.js
+++ b/tests/ui-tests/commands/console.js
@@ -22,10 +22,12 @@ async function _loginViaDex(page, config) {
     await page.waitForSelector('#password');
     await page.type('#password', config.password);
     await page.waitForSelector(loginButtonSelector);
-    await page.click(loginButtonSelector);
-    return page.waitForNavigation({
-      waitUntil: ['domcontentloaded', 'networkidle0']
-    });
+    return Promise.all([
+      page.click(loginButtonSelector),
+      page.waitForNavigation({
+        waitUntil: ['domcontentloaded', 'networkidle0']
+      })
+    ]);
   } catch (err) {
     throw new Error(`Couldn't log in`, err);
   }

--- a/tests/ui-tests/tests/catalog-ui-test.js
+++ b/tests/ui-tests/tests/catalog-ui-test.js
@@ -47,9 +47,12 @@ describeIf(dex.isStaticUser(), 'Catalog basic tests', () => {
     const searchSelector = catalog.prepareSelector('search');
     const searchBySth = 'lololo';
 
-    await page.goto(address.console.getCatalog(config.catalogTestEnv), {
-      waitUntil: ['domcontentloaded', 'networkidle0']
-    });
+    await Promise.all([
+      page.goto(address.console.getCatalog(config.catalogTestEnv)),
+      page.waitForNavigation({
+        waitUntil: ['domcontentloaded', 'networkidle0']
+      })
+    ]);
     const frame = await kymaConsole.getFrame(page);
     await frame.waitForSelector(catalogHeaderSelector);
     const catalogHeader = await frame.$eval(

--- a/tests/ui-tests/tests/console-basic-test.js
+++ b/tests/ui-tests/tests/console-basic-test.js
@@ -96,7 +96,7 @@ describeIf(dex.isStaticUser(), 'Console basic tests', () => {
   test('Create Application', async () => {
     await common.retry(page, async () => {
       await page.reload({ waitUntil: ['domcontentloaded', 'networkidle0'] });
-      return kymaConsole.createRemoteEnvironment(page, config.testEnv);
+      await kymaConsole.createRemoteEnvironment(page, config.testEnv);
     });
     await page.reload({ waitUntil: ['domcontentloaded', 'networkidle0'] });
     const remoteEnvironments = await kymaConsole.getRemoteEnvironmentNames(

--- a/tests/ui-tests/tests/console-basic-test.js
+++ b/tests/ui-tests/tests/console-basic-test.js
@@ -16,6 +16,16 @@ describeIf(dex.isStaticUser(), 'Console basic tests', () => {
       browser = data.browser;
       page = data.page;
       logOnEvents(page, t => (token = t));
+
+      //throw an error for NETWORK_CHANGED case so that it can be retried
+      page.on('requestfailed', request => {
+        if (request._failureText === 'net::ERR_NETWORK_CHANGED') {
+          console.log(
+            'Error net::ERR_NETWORK_CHANGED. Operation will be retried'
+          );
+          throw new Error('ERR_NETWORK_CHANGED');
+        }
+      });
       await kymaConsole.testLogin(page);
     } catch (e) {
       throw e;
@@ -84,7 +94,10 @@ describeIf(dex.isStaticUser(), 'Console basic tests', () => {
   });
 
   test('Create Application', async () => {
-    await kymaConsole.createRemoteEnvironment(page, config.testEnv);
+    await common.retry(page, async () => {
+      await page.reload({ waitUntil: ['domcontentloaded', 'networkidle0'] });
+      return kymaConsole.createRemoteEnvironment(page, config.testEnv);
+    });
     await page.reload({ waitUntil: ['domcontentloaded', 'networkidle0'] });
     const remoteEnvironments = await kymaConsole.getRemoteEnvironmentNames(
       page

--- a/tests/ui-tests/utils/testContext.js
+++ b/tests/ui-tests/utils/testContext.js
@@ -15,7 +15,6 @@ const context = (function() {
         ignoreHTTPSErrors: true,
         headless: config.headless,
         slowMo: 80,
-        devtools: true,
         args: [
           `--window-size=${config.viewportWidth},${config.viewportHeight}`,
           '--no-sandbox',


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix promise synchronisation in ui test login
- Fix navigation timeout in catalog-ui test
- Add retry handler in case of `net::ERR_NETWORK_CHANGED` error
- disable devtools

