### PR TITLE
Apply backend modules data to deployments view

### DIFF
--- a/core/src/app/app.module.ts
+++ b/core/src/app/app.module.ts
@@ -71,6 +71,7 @@ import { UploaderComponent } from './shared/components/resource-uploader/uploade
 import { ComponentCommunicationService } from './shared/services/component-communication.service';
 import { RoleBindingModalComponent } from './shared/components/role-binding-modal/role-binding-modal.component';
 import { GraphQLClientService } from './shared/services/graphql-client-service';
+import { LuigiClientService } from './shared/services/luigi-client.service';
 import { ClickOutsideModule } from 'ng-click-outside';
 import { PermissionsComponent } from './shared/components/permissions/permissions.component';
 import { RolesComponent } from './shared/components/permissions/roles/roles.component';
@@ -216,7 +217,8 @@ import { FundamentalNgxModule } from 'fundamental-ngx';
     RemoteEnvironmentBindingService,
     RbacService,
     GraphQLClientService,
-    IdpPresetsService
+    IdpPresetsService,
+    LuigiClientService
   ],
   entryComponents: [
     EnvironmentCardComponent,

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
@@ -8,14 +8,14 @@
   <div class="col-1" *ngIf="showBoundServices && entry.boundServiceInstanceNames && entry.boundServiceInstanceNames.length > 0">
     <span *ngFor="let instance of entry.boundServiceInstanceNames">{{ instance }}</span>
   </div>
-  <div class="col-1" *ngIf="!entry.boundServiceInstanceNames || entry.boundServiceInstanceNames.length === 0">
+  <div class="col-1" *ngIf="showBoundServices && (!entry.boundServiceInstanceNames || entry.boundServiceInstanceNames.length === 0)">
     <span></span>
   </div>
-  <div class="col-2 sf-list__label-column">
+  <div class="sf-list__label-column" ngClass="{{showBoundServices ? 'col-2' : 'col-3'}}">
     <span class="tn-badge tn-badge--pill sf-list__label" *ngFor="let label of getLabels(entry.labels)">{{ label }}</span>
   </div>
   <div class="col-2">
-      <app-status-label 
+      <app-status-label
         [statusType]="getStatusType(entry)">
         {{ getStatus(entry) }}
       </app-status-label>

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
@@ -5,7 +5,7 @@
   <div class="col-2">
     <span *ngFor="let image of entry.containers">{{ image.image }}</span>
   </div>
-  <div class="col-1" *ngIf="entry.boundServiceInstanceNames && entry.boundServiceInstanceNames.length > 0">
+  <div class="col-1" *ngIf="showBoundServices && entry.boundServiceInstanceNames && entry.boundServiceInstanceNames.length > 0">
     <span *ngFor="let instance of entry.boundServiceInstanceNames">{{ instance }}</span>
   </div>
   <div class="col-1" *ngIf="!entry.boundServiceInstanceNames || entry.boundServiceInstanceNames.length === 0">

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
@@ -2,19 +2,21 @@
   <div class="col-2 col-lg-2 sf-list__body--primary">{{ entry.name }}</div>
   <div class="col-1">{{ entry.status.readyReplicas ? entry.status.readyReplicas : 0 }} /{{ entry.status.replicas }}</div>
   <div class="col-1">{{ entry.creationTimestamp * 1000 | timeAgo }}</div>
-  <div class="col-2">
+  <div ngClass="{{showBoundServices ? 'col-2' : 'col-3'}}">
     <span *ngFor="let image of entry.containers">{{ image.image }}</span>
   </div>
-  <div class="col-1" *ngIf="showBoundServices && entry.boundServiceInstanceNames && entry.boundServiceInstanceNames.length > 0">
-    <span *ngFor="let instance of entry.boundServiceInstanceNames">{{ instance }}</span>
-  </div>
-  <div class="col-1" *ngIf="showBoundServices && (!entry.boundServiceInstanceNames || entry.boundServiceInstanceNames.length === 0)">
-    <span></span>
-  </div>
+  <ng-container *ngIf="showBoundServices">
+    <div class="col-2" *ngIf="entry.boundServiceInstanceNames && entry.boundServiceInstanceNames.length > 0">
+      <span *ngFor="let instance of entry.boundServiceInstanceNames">{{ instance }}</span>
+    </div>
+    <div class="col-2" *ngIf="(!entry.boundServiceInstanceNames || entry.boundServiceInstanceNames.length === 0)">
+      <span></span>
+    </div>
+  </ng-container>
   <div class="sf-list__label-column" ngClass="{{showBoundServices ? 'col-2' : 'col-3'}}">
     <span class="tn-badge tn-badge--pill sf-list__label" *ngFor="let label of getLabels(entry.labels)">{{ label }}</span>
   </div>
-  <div class="col-2">
+  <div class="col-1">
       <app-status-label
         [statusType]="getStatusType(entry)">
         {{ getStatus(entry) }}

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
@@ -7,7 +7,9 @@
   </div>
   <ng-container *ngIf="showBoundServices">
     <div class="col-2" *ngIf="entry.boundServiceInstanceNames && entry.boundServiceInstanceNames.length > 0">
-      <span *ngFor="let instance of entry.boundServiceInstanceNames">{{ instance }}</span>
+      <a *ngFor="let instance of entry.boundServiceInstanceNames" (click)="goToServiceInstanceDetails(instance)">
+        {{ instance }}
+      </a>
     </div>
     <div class="col-2" *ngIf="(!entry.boundServiceInstanceNames || entry.boundServiceInstanceNames.length === 0)">
       <span></span>

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
@@ -7,7 +7,7 @@
   </div>
   <ng-container *ngIf="showBoundServices">
     <div class="col-2" *ngIf="entry.boundServiceInstanceNames && entry.boundServiceInstanceNames.length > 0">
-      <a *ngFor="let instance of entry.boundServiceInstanceNames" (click)="goToServiceInstanceDetails(instance)">
+      <a class="bound-services" *ngFor="let instance of entry.boundServiceInstanceNames" (click)="goToServiceInstanceDetails(instance)">
         {{ instance }}
       </a>
     </div>

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.scss
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.scss
@@ -1,0 +1,3 @@
+.bound-services {
+  cursor: pointer;
+}

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.spec.ts
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.spec.ts
@@ -4,13 +4,19 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DeploymentEntryRendererComponent } from './deployment-entry-renderer.component';
 import { ComponentCommunicationService } from '../../../../../shared/services/component-communication.service';
 import { of, Subject } from 'rxjs';
+import { LuigiClientService } from 'shared/services/luigi-client.service';
 
 describe('DeploymentEntryRendererComponent', () => {
   let component: DeploymentEntryRendererComponent;
   let fixture: ComponentFixture<DeploymentEntryRendererComponent>;
   let componentCommunicationService: ComponentCommunicationService;
+  let luigiClientService: LuigiClientService;
 
   beforeEach(async(() => {
+    const mockLuigiClientService = {
+      hasBackendModule: () => true
+    };
+
     TestBed.configureTestingModule({
       imports: [AppModule],
       providers: [
@@ -28,7 +34,8 @@ describe('DeploymentEntryRendererComponent', () => {
           }
         ],
         [{ provide: 'entryEventHandler', useValue: {} }],
-        ComponentCommunicationService
+        ComponentCommunicationService,
+        { provide: LuigiClientService, useValue: mockLuigiClientService }
       ]
     }).compileComponents();
   }));
@@ -36,12 +43,23 @@ describe('DeploymentEntryRendererComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DeploymentEntryRendererComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
     componentCommunicationService = TestBed.get(ComponentCommunicationService);
+    luigiClientService = TestBed.get(LuigiClientService);
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it("set 'showBoundService' value on component init", () => {
+    expect(this.showBoundServices).toBeUndefined();
+    spyOn(luigiClientService, 'hasBackendModule').and.returnValue(true);
+    fixture.detectChanges();
+    expect(luigiClientService.hasBackendModule).toHaveBeenCalledWith(
+      'servicecatalogaddons'
+    );
+    expect(component.showBoundServices).toBe(true);
   });
 
   it("should disable the deployment if 'disable' event with rigth data has been sent", async done => {

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.ts
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.ts
@@ -33,7 +33,6 @@ export class DeploymentEntryRendererComponent
         }
       }
     );
-
     this.showBoundServices = this.luigiClientService.hasBackendModule(
       'servicecatalogaddons'
     );

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.ts
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.ts
@@ -3,6 +3,7 @@ import { AbstractKubernetesEntryRendererComponent } from '../../abstract-kuberne
 import { ComponentCommunicationService } from '../../../../../shared/services/component-communication.service';
 import { Subscription } from 'rxjs';
 import { StatusLabelComponent } from '../../../../../shared/components/status-label/status-label.component';
+import { LuigiClientService } from '../../../../../shared/services/luigi-client.service';
 
 @Component({
   selector: 'app-deployment-entry-renderer',
@@ -14,11 +15,13 @@ export class DeploymentEntryRendererComponent
   implements OnInit, OnDestroy {
   constructor(
     protected injector: Injector,
-    private componentCommunicationService: ComponentCommunicationService
+    private componentCommunicationService: ComponentCommunicationService,
+    private luigiClientService: LuigiClientService
   ) {
     super(injector);
   }
   public disabled = false;
+  public showBoundServices: boolean;
   private communicationServiceSubscription: Subscription;
 
   ngOnInit() {
@@ -29,6 +32,10 @@ export class DeploymentEntryRendererComponent
           this.disabled = event.entry.disabled;
         }
       }
+    );
+
+    this.showBoundServices = this.luigiClientService.hasBackendModule(
+      'servicecatalogaddons'
     );
   }
 

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.ts
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.ts
@@ -1,7 +1,7 @@
 import { Component, Injector, OnInit, OnDestroy } from '@angular/core';
 import LuigiClient from '@kyma-project/luigi-client';
 
-import { CurrentEnvironmentService } from '../../../services/current-environment.service';
+import { CurrentEnvironmentService } from 'environments/services/current-environment.service';
 import { AbstractKubernetesEntryRendererComponent } from '../../abstract-kubernetes-entry-renderer.component';
 import { ComponentCommunicationService } from '../../../../../shared/services/component-communication.service';
 import { Subscription } from 'rxjs';

--- a/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.ts
+++ b/core/src/app/content/environments/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.ts
@@ -3,7 +3,7 @@ import { AbstractKubernetesEntryRendererComponent } from '../../abstract-kuberne
 import { ComponentCommunicationService } from '../../../../../shared/services/component-communication.service';
 import { Subscription } from 'rxjs';
 import { StatusLabelComponent } from '../../../../../shared/components/status-label/status-label.component';
-import { LuigiClientService } from '../../../../../shared/services/luigi-client.service';
+import { LuigiClientService } from 'shared/services/luigi-client.service';
 
 @Component({
   selector: 'app-deployment-entry-renderer',

--- a/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.html
+++ b/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.html
@@ -3,7 +3,7 @@
   <div class="col-1">Pods</div>
   <div class="col-1">Age</div>
   <div class="col-2">Images</div>
-  <div class="col-1">Bound apps</div>
+  <div class="col-1" *ngIf="showBoundServices">Bound apps</div>
   <div class="col-2">Labels</div>
   <div class="col-2">Status</div>
   <div class="col-1 actions-icon">Actions</div>

--- a/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.html
+++ b/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.html
@@ -2,9 +2,9 @@
   <div class="col-2 col-lg-2">Name</div>
   <div class="col-1">Pods</div>
   <div class="col-1">Age</div>
-  <div class="col-2">Images</div>
-  <div class="col-1" *ngIf="showBoundServices">Bound services</div>
+  <div ngClass="{{showBoundServices ? 'col-2' : 'col-3'}}">Images</div>
+  <div class="col-2" *ngIf="showBoundServices">Bound services</div>
   <div ngClass="{{showBoundServices ? 'col-2' : 'col-3'}}">Labels</div>
-  <div class="col-2">Status</div>
+  <div class="col-1">Status</div>
   <div class="col-1 actions-icon">Actions</div>
 </div>

--- a/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.html
+++ b/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.html
@@ -3,8 +3,8 @@
   <div class="col-1">Pods</div>
   <div class="col-1">Age</div>
   <div class="col-2">Images</div>
-  <div class="col-1" *ngIf="showBoundServices">Bound apps</div>
-  <div class="col-2">Labels</div>
+  <div class="col-1" *ngIf="showBoundServices">Bound services</div>
+  <div ngClass="{{showBoundServices ? 'col-2' : 'col-3'}}">Labels</div>
   <div class="col-2">Status</div>
   <div class="col-1 actions-icon">Actions</div>
 </div>

--- a/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.html
+++ b/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.html
@@ -3,7 +3,7 @@
   <div class="col-1">Pods</div>
   <div class="col-1">Age</div>
   <div ngClass="{{showBoundServices ? 'col-2' : 'col-3'}}">Images</div>
-  <div class="col-2" *ngIf="showBoundServices">Bound services</div>
+  <div class="col-2" *ngIf="showBoundServices">Bound service instances</div>
   <div ngClass="{{showBoundServices ? 'col-2' : 'col-3'}}">Labels</div>
   <div class="col-1">Status</div>
   <div class="col-1 actions-icon">Actions</div>

--- a/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.spec.ts
+++ b/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.spec.ts
@@ -1,25 +1,44 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DeploymentHeaderRendererComponent } from './deployment-header-renderer.component';
+import { LuigiClientService } from 'shared/services/luigi-client.service';
 
 describe('DeploymentHeaderRendererComponent', () => {
   let component: DeploymentHeaderRendererComponent;
   let fixture: ComponentFixture<DeploymentHeaderRendererComponent>;
+  let luigiClientService: LuigiClientService;
 
   beforeEach(async(() => {
+    const mockLuigiClientService = {
+      hasBackendModule: () => true
+    };
+
     TestBed.configureTestingModule({
-      declarations: [ DeploymentHeaderRendererComponent ]
-    })
-    .compileComponents();
+      declarations: [DeploymentHeaderRendererComponent],
+      providers: [
+        { provide: LuigiClientService, useValue: mockLuigiClientService }
+      ]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DeploymentHeaderRendererComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    luigiClientService = TestBed.get(LuigiClientService);
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it("set 'showBoundService' value on component init", () => {
+    expect(this.showBoundServices).toBeUndefined();
+    spyOn(luigiClientService, 'hasBackendModule').and.returnValue(true);
+    fixture.detectChanges();
+    expect(luigiClientService.hasBackendModule).toHaveBeenCalledWith(
+      'servicecatalogaddons'
+    );
+    expect(component.showBoundServices).toBe(true);
   });
 });

--- a/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.ts
+++ b/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { LuigiClientService } from '../../../../../shared/services/luigi-client.service';
 
 @Component({
   selector: 'app-deployment-header-renderer',
@@ -6,10 +7,13 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./deployment-header-renderer.component.scss']
 })
 export class DeploymentHeaderRendererComponent implements OnInit {
+  public showBoundServices: boolean;
 
-  constructor() { }
+  constructor(private luigiClientService: LuigiClientService) {}
 
   ngOnInit() {
+    this.showBoundServices = this.luigiClientService.hasBackendModule(
+      'servicecatalogaddons'
+    );
   }
-
 }

--- a/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.ts
+++ b/core/src/app/content/environments/operation/deployments/deployment-header-renderer/deployment-header-renderer.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { LuigiClientService } from '../../../../../shared/services/luigi-client.service';
+
+import { LuigiClientService } from 'shared/services/luigi-client.service';
 
 @Component({
   selector: 'app-deployment-header-renderer',

--- a/core/src/app/shared/services/luigi-client.service.spec.ts
+++ b/core/src/app/shared/services/luigi-client.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LuigiClientService } from './luigi-client.service';
+
+describe('LuigiClientService', () => {
+  let luigiClientService: LuigiClientService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [LuigiClientService]
+    });
+
+    luigiClientService = TestBed.get(LuigiClientService);
+  });
+
+  describe('hasBackendModule()', () => {
+    beforeEach(() => {
+      luigiClientService['luigiClient'] = {
+        getEventData: jasmine.createSpy('getEventData')
+      };
+      luigiClientService['luigiClient'].getEventData.and.returnValue({
+        backendModules: ['a', 'b', 'c', 'd']
+      });
+    });
+
+    it('returns true if backend module exists', () => {
+      expect(luigiClientService.hasBackendModule('b')).toBe(true);
+    });
+
+    it('returns false if backend module does not exist', () => {
+      expect(luigiClientService.hasBackendModule('s')).toBe(false);
+    });
+  });
+});

--- a/core/src/app/shared/services/luigi-client.service.ts
+++ b/core/src/app/shared/services/luigi-client.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import LuigiClient from '@kyma-project/luigi-client';
+
+@Injectable()
+export class LuigiClientService {
+  public hasBackendModule(backendModule: string): boolean {
+    const backendModules: string[] =
+      LuigiClient.getEventData().backendModules || [];
+    return Boolean(backendModules.find((x: string) => x === backendModule));
+  }
+}

--- a/core/src/app/shared/services/luigi-client.service.ts
+++ b/core/src/app/shared/services/luigi-client.service.ts
@@ -3,9 +3,15 @@ import LuigiClient from '@kyma-project/luigi-client';
 
 @Injectable()
 export class LuigiClientService {
+  private luigiClient: LuigiClient;
+
+  constructor() {
+    this.luigiClient = LuigiClient;
+  }
+
   public hasBackendModule(backendModule: string): boolean {
     const backendModules: string[] =
-      LuigiClient.getEventData().backendModules || [];
+      this.luigiClient.getEventData().backendModules || [];
     return Boolean(backendModules.find((x: string) => x === backendModule));
   }
 }

--- a/core/src/tsconfig.app.json
+++ b/core/src/tsconfig.app.json
@@ -4,10 +4,10 @@
     "outDir": "../out-tsc/app",
     "baseUrl": "./",
     "module": "es2015",
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      "shared/*": ["app/shared/*"]
+    }
   },
-  "exclude": [
-    "test.ts",
-    "**/*.spec.ts"
-  ]
+  "exclude": ["test.ts", "**/*.spec.ts"]
 }

--- a/core/src/tsconfig.app.json
+++ b/core/src/tsconfig.app.json
@@ -6,7 +6,8 @@
     "module": "es2015",
     "types": ["node"],
     "paths": {
-      "shared/*": ["app/shared/*"]
+      "shared/*": ["app/shared/*"],
+      "environments/*": ["app/content/environments/*"]
     }
   },
   "exclude": ["test.ts", "**/*.spec.ts"]

--- a/core/src/tsconfig.spec.json
+++ b/core/src/tsconfig.spec.json
@@ -5,7 +5,10 @@
     "baseUrl": "./",
     "module": "commonjs",
     "target": "es5",
-    "types": ["jasmine", "node"]
+    "types": ["jasmine", "node"],
+    "paths": {
+      "shared/*": ["app/shared/*"]
+    }
   },
   "files": ["test.ts", "polyfills.ts"],
   "include": ["**/*.spec.ts", "**/*.d.ts"]

--- a/core/src/tsconfig.spec.json
+++ b/core/src/tsconfig.spec.json
@@ -7,7 +7,8 @@
     "target": "es5",
     "types": ["jasmine", "node"],
     "paths": {
-      "shared/*": ["app/shared/*"]
+      "shared/*": ["app/shared/*"],
+      "environments/*": ["app/content/environments/*"]
     }
   },
   "files": ["test.ts", "polyfills.ts"],

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -11,7 +11,10 @@
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2017", "dom", "esnext"],
     "module": "es2015",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "paths": {
+      "shared/*": ["src/app/shared/*"]
+    }
   },
   "include": ["src/**/*", "node_modules/ng2-ace-editor/src/**/*"]
 }

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -13,7 +13,8 @@
     "module": "es2015",
     "baseUrl": "./",
     "paths": {
-      "shared/*": ["src/app/shared/*"]
+      "shared/*": ["src/app/shared/*"],
+      "environments/*": ["src/app/content/environments/*"]
     }
   },
   "include": ["src/**/*", "node_modules/ng2-ace-editor/src/**/*"]

--- a/core/tslint.json
+++ b/core/tslint.json
@@ -37,8 +37,10 @@
       "@angular/common/http",
       "@angular/router/src/utils/collection",
       "@angular/http/testing",
-      "@angular/router/testing"
+      "@angular/router/testing",
+      "shared"
     ],
+    "no-implicit-dependencies": [true, ["shared"]],
     "interface-name": false
   },
   "rulesDirectory": ["node_modules/codelyzer"],

--- a/core/tslint.json
+++ b/core/tslint.json
@@ -38,9 +38,10 @@
       "@angular/router/src/utils/collection",
       "@angular/http/testing",
       "@angular/router/testing",
-      "shared"
+      "shared",
+      "environments"
     ],
-    "no-implicit-dependencies": [true, ["shared"]],
+    "no-implicit-dependencies": [true, ["shared", "environments"]],
     "interface-name": false
   },
   "rulesDirectory": ["node_modules/codelyzer"],


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Show "bound apps" column in deployments table only if there is a backend module called 'servicecatalogaddons'
- In deployments view, replace the header name "Bound apps" with "Bound services" and make the name of the bounded service instances clickable, so that the user can go to the instance details.
- Write unit tests
- Introduce ts config 'paths' feature for shorter and easier to write imports.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
