### PR TITLE
Rename environments to namespaces in ui-api-layer under application domain

### DIFF
--- a/core/src/app/content/settings/remote-environments/remote-environment-details/remote-environment-binding-service.ts
+++ b/core/src/app/content/settings/remote-environments/remote-environment-details/remote-environment-binding-service.ts
@@ -24,7 +24,7 @@ export class RemoteEnvironmentBindingService {
 
   public bind(environment, remoteEnvironment) {
     const query = `mutation($environment: String!, $remoteEnvironment: String!){
-      enableApplication(environment: $environment, application: $remoteEnvironment) {
+      enableApplication(namespace: $environment, application: $remoteEnvironment) {
         environment
         application
       }
@@ -42,7 +42,7 @@ export class RemoteEnvironmentBindingService {
 
   public unbind(environment, remoteEnvironment) {
     const query = `mutation($environment: String!, $remoteEnvironment: String!){
-      disableApplication(environment: $environment, application: $remoteEnvironment) {
+      disableApplication(namespace: $environment, application: $remoteEnvironment) {
         environment
         application
       }
@@ -74,7 +74,7 @@ export class RemoteEnvironmentBindingService {
 
   public getBoundRemoteEnvironments(environment) {
     const query = `query Application($environment: String!){
-      applications(environment: $environment) {
+      applications(namespace: $environment) {
         name
       }
     }`;

--- a/core/src/app/content/settings/remote-environments/remote-environment-details/remote-environment-binding-service.ts
+++ b/core/src/app/content/settings/remote-environments/remote-environment-details/remote-environment-binding-service.ts
@@ -25,7 +25,7 @@ export class RemoteEnvironmentBindingService {
   public bind(environment, remoteEnvironment) {
     const query = `mutation($environment: String!, $remoteEnvironment: String!){
       enableApplication(namespace: $environment, application: $remoteEnvironment) {
-        environment
+        namespace
         application
       }
     }`;
@@ -43,7 +43,7 @@ export class RemoteEnvironmentBindingService {
   public unbind(environment, remoteEnvironment) {
     const query = `mutation($environment: String!, $remoteEnvironment: String!){
       disableApplication(namespace: $environment, application: $remoteEnvironment) {
-        environment
+        namespace
         application
       }
     }`;

--- a/lambda/src/app/event-activations/event-activations.service.spec.ts
+++ b/lambda/src/app/event-activations/event-activations.service.spec.ts
@@ -33,7 +33,7 @@ describe('EventActivationsService', () => {
     const namespace = 'fakeNamespace';
     const token = 'fakeToken';
     const expectedQuery = `query EventActivations($environment: String!) {
-      eventActivations(environment: $environment) {
+      eventActivations(namespace: $environment) {
         name
         displayName
         sourceId

--- a/lambda/src/app/event-activations/event-activations.service.ts
+++ b/lambda/src/app/event-activations/event-activations.service.ts
@@ -19,7 +19,7 @@ export class EventActivationsService {
     token: string,
   ): Observable<EventActivationResponse> {
     const query = `query EventActivations($environment: String!) {
-      eventActivations(environment: $environment) {
+      eventActivations(namespace: $environment) {
         name
         displayName
         sourceId


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Rename environments to namespaces in queries from ui-api-layer under application domain

**Related issue(s)**

See also the [issue #2214](https://github.com/kyma-project/kyma/issues/2214)
See also the [PR with API change #2328](https://github.com/kyma-project/kyma/pull/2328)
See also the [bump #2339](https://github.com/kyma-project/kyma/pull/2339) 