### PR TITLE
Apply env label for test namespace

### DIFF
--- a/tests/ui-tests/setup/namespace-manager.js
+++ b/tests/ui-tests/setup/namespace-manager.js
@@ -15,7 +15,7 @@ export class NamespaceManager {
     }
 
     console.log(`Creating namespace ${this.namespaceName}...`);
-    await this.api.createNamespace(this.getNonSystemNamespaceObj());
+    await this.api.createNamespace(this.getNamespaceObj());
   }
 
   async deleteIfExists() {
@@ -30,14 +30,6 @@ export class NamespaceManager {
   }
 
   getNamespaceObj() {
-    return {
-      metadata: {
-        name: this.namespaceName
-      }
-    };
-  }
-
-  getNonSystemNamespaceObj() {
     return {
       metadata: {
         name: this.namespaceName,

--- a/tests/ui-tests/setup/namespace-manager.js
+++ b/tests/ui-tests/setup/namespace-manager.js
@@ -15,7 +15,7 @@ export class NamespaceManager {
     }
 
     console.log(`Creating namespace ${this.namespaceName}...`);
-    await this.api.createNamespace(this.getNamespaceObj());
+    await this.api.createNamespace(this.getNonSystemNamespaceObj());
   }
 
   async deleteIfExists() {
@@ -33,6 +33,15 @@ export class NamespaceManager {
     return {
       metadata: {
         name: this.namespaceName
+      }
+    };
+  }
+
+  getNonSystemNamespaceObj() {
+    return {
+      metadata: {
+        name: this.namespaceName,
+        labels: { env: 'true' }
       }
     };
   }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Apply `env:true` label for the test namespace, so that service-catalog MFs are available for the ui tests

**Related issue(s)**
https://github.com/kyma-project/console/issues/599
