### PR TITLE
664 bug in firefox for action bar

### DIFF
--- a/core/src/styles/fiori-fundamentals-overrides.scss
+++ b/core/src/styles/fiori-fundamentals-overrides.scss
@@ -23,6 +23,12 @@
 }
 
 .fd-action-bar {
+
+  align-items: center; /* There is a bug in Fiori Fundamentals.
+                          In Firefox button in `fd-action-bar-actions`
+                          are shifted to the bottom.
+                       */
+
   &__actions {
     flex-shrink: 0;
     .fd-popover {

--- a/core/src/styles/fiori-fundamentals-overrides.scss
+++ b/core/src/styles/fiori-fundamentals-overrides.scss
@@ -25,7 +25,7 @@
 .fd-action-bar {
 
   align-items: center; /* There is a bug in Fiori Fundamentals.
-                          In Firefox button in `fd-action-bar-actions`
+                          In Firefox buttons in `fd-action-bar-actions`
                           are shifted to the bottom.
                        */
 

--- a/lambda/src/styles/fiori-fundamentals-overrides.scss
+++ b/lambda/src/styles/fiori-fundamentals-overrides.scss
@@ -65,6 +65,12 @@
   }
 }
 .fd-action-bar {
+
+  align-items: center; /* There is a bug in Fiori Fundamentals.
+                          In Firefox button in `fd-action-bar-actions`
+                          are shifted to the bottom.
+                       */
+
   &__actions {
     flex-shrink: 0; //another bug when search input is expanded
     .fd-popover {

--- a/lambda/src/styles/fiori-fundamentals-overrides.scss
+++ b/lambda/src/styles/fiori-fundamentals-overrides.scss
@@ -67,7 +67,7 @@
 .fd-action-bar {
 
   align-items: center; /* There is a bug in Fiori Fundamentals.
-                          In Firefox button in `fd-action-bar-actions`
+                          In Firefox buttons in `fd-action-bar-actions`
                           are shifted to the bottom.
                        */
 


### PR DESCRIPTION
Buttons in action bar are vertically align now with headline.