### PR TITLE
Fix Safari bug with Popovers

### DIFF
--- a/core/src/styles/fiori-fundamentals-overrides.scss
+++ b/core/src/styles/fiori-fundamentals-overrides.scss
@@ -171,5 +171,5 @@ a {
 // Fix for popover could not be opened on Safari (also causing some infinite operations eating all resources)
 // It should not provide any visual changes
 .fd-popover__body {
-  transition: all 0.135s, transformZ 0;
+  transition: all 0.135s, transformZ 0s;
 }

--- a/core/src/styles/fiori-fundamentals-overrides.scss
+++ b/core/src/styles/fiori-fundamentals-overrides.scss
@@ -167,3 +167,9 @@
 a {
   cursor: pointer;
 }
+
+// Fix for popover could not be opened on Safari (also causing some infinite operations eating all resources)
+// It should not provide any visual changes
+.fd-popover__body {
+  transition: all 0.135s, transformZ 0;
+}

--- a/core/src/styles/fiori-fundamentals-overrides.scss
+++ b/core/src/styles/fiori-fundamentals-overrides.scss
@@ -169,7 +169,16 @@ a {
 }
 
 // Fix for popover could not be opened on Safari (also causing some infinite operations eating all resources)
-// It should not provide any visual changes
+// Transform property causes problem in Safari. Workaround removes `transform` and uses `margin-top` instead
+.fd-popover__body  {
+  margin-top: 0;
+  transform: none;
+}
+
 .fd-popover__body {
-  transition: all 0.135s, transformZ 0s;
+  &[aria-hidden='true'], 
+  &.is-hidden {
+    margin-top: -15px;
+    transform: none;
+  }
 }

--- a/lambda/src/styles/fiori-fundamentals-overrides.scss
+++ b/lambda/src/styles/fiori-fundamentals-overrides.scss
@@ -192,5 +192,5 @@ a {
 // Fix for popover could not be opened on Safari (also causing some infinite operations eating all resources)
 // It should not provide any visual changes
 .fd-popover__body {
-  transition: all 0.135s, transformZ 0;
+  transition: all 0.135s, transformZ 0s;
 }

--- a/lambda/src/styles/fiori-fundamentals-overrides.scss
+++ b/lambda/src/styles/fiori-fundamentals-overrides.scss
@@ -188,3 +188,9 @@
 a {
   cursor: pointer;
 }
+
+// Fix for popover could not be opened on Safari (also causing some infinite operations eating all resources)
+// It should not provide any visual changes
+.fd-popover__body {
+  transition: all 0.135s, transformZ 0;
+}

--- a/lambda/src/styles/fiori-fundamentals-overrides.scss
+++ b/lambda/src/styles/fiori-fundamentals-overrides.scss
@@ -190,7 +190,16 @@ a {
 }
 
 // Fix for popover could not be opened on Safari (also causing some infinite operations eating all resources)
-// It should not provide any visual changes
+// Transform property causes problem in Safari. Workaround removes `transform` and uses `margin-top` instead
+.fd-popover__body  {
+  margin-top: 0;
+  transform: none;
+}
+
 .fd-popover__body {
-  transition: all 0.135s, transformZ 0s;
+  &[aria-hidden='true'], 
+  &.is-hidden {
+    margin-top: -15px;
+    transform: none;
+  }
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
It looks like Safari tries to do some fictional `translateZ` transition on Popover's body.
I disabled it and it works fine. There are no visual changes (transition works like id did before) because there was actually no Z-axis change (Safari thinks different).
Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
