### PR TITLE
List of applications is not loaded after editing one entry

### DIFF
--- a/core/src/app/content/environments/operation/secrets/secret-detail/secret-detail.component.html
+++ b/core/src/app/content/environments/operation/secrets/secret-detail/secret-detail.component.html
@@ -1,5 +1,5 @@
 <section class="fd-section">
-  <fd-breadcrumb class="y-fd-breadcrumb">
+  <fd-breadcrumb>
     <fd-breadcrumb-item>
       <a fd-breadcrumb-link (click)="navigateToList()">
         Secrets

--- a/core/src/app/content/environments/operation/services/service-details/expose-api/expose-api.component.html
+++ b/core/src/app/content/environments/operation/services/service-details/expose-api/expose-api.component.html
@@ -1,5 +1,5 @@
 <section class="fd-section">
-  <fd-breadcrumb class="y-fd-breadcrumb" *ngIf="routedFromServiceDetails">
+  <fd-breadcrumb *ngIf="routedFromServiceDetails">
     <fd-breadcrumb-item>
       <a fd-breadcrumb-link (click)="navigateToList('services')">Services</a>
     </fd-breadcrumb-item>
@@ -13,7 +13,7 @@
     </fd-breadcrumb-item>
   </fd-breadcrumb>
 
-  <fd-breadcrumb class="y-fd-breadcrumb" *ngIf="!routedFromServiceDetails">
+  <fd-breadcrumb *ngIf="!routedFromServiceDetails">
     <fd-breadcrumb-item>
       <a fd-breadcrumb-link (click)="navigateToList('cmf-apis')">APIs</a>
     </fd-breadcrumb-item>

--- a/core/src/app/content/environments/operation/services/service-details/service-details.component.html
+++ b/core/src/app/content/environments/operation/services/service-details/service-details.component.html
@@ -1,5 +1,5 @@
 <section class="fd-section">
-  <fd-breadcrumb class="y-fd-breadcrumb">
+  <fd-breadcrumb>
     <fd-breadcrumb-item>
       <a fd-breadcrumb-link (click)="navigateToList()" href="#">
         Services

--- a/core/src/app/content/environments/operation/services/service-details/service-details.component.html
+++ b/core/src/app/content/environments/operation/services/service-details/service-details.component.html
@@ -1,7 +1,7 @@
 <section class="fd-section">
   <fd-breadcrumb>
     <fd-breadcrumb-item>
-      <a fd-breadcrumb-link (click)="navigateToList()" href="#">
+      <a fd-breadcrumb-link (click)="navigateToList()">
         Services
       </a>
     </fd-breadcrumb-item>

--- a/core/src/app/content/settings/remote-environments/remote-environment-details/remote-environment-details.component.html
+++ b/core/src/app/content/settings/remote-environments/remote-environment-details/remote-environment-details.component.html
@@ -1,7 +1,7 @@
 <section class="fd-section">
   <fd-breadcrumb>
     <fd-breadcrumb-item>
-      <a fd-breadcrumb-link (click)="navigateToList()" href="#">
+      <a fd-breadcrumb-link (click)="navigateToList()">
         Applications
       </a>
     </fd-breadcrumb-item>

--- a/core/src/app/content/settings/remote-environments/remote-environment-details/remote-environment-details.component.html
+++ b/core/src/app/content/settings/remote-environments/remote-environment-details/remote-environment-details.component.html
@@ -1,5 +1,5 @@
 <section class="fd-section">
-  <fd-breadcrumb class="y-fd-breadcrumb">
+  <fd-breadcrumb>
     <fd-breadcrumb-item>
       <a fd-breadcrumb-link (click)="navigateToList()" href="#">
         Applications

--- a/core/src/app/shared/components/permissions/role-details/role-details.component.html
+++ b/core/src/app/shared/components/permissions/role-details/role-details.component.html
@@ -1,5 +1,5 @@
 <section class="fd-section">
-  <fd-breadcrumb class="y-fd-breadcrumb">
+  <fd-breadcrumb>
     <fd-breadcrumb-item>
       <a fd-breadcrumb-link (click)="navigateToList()">
         Permissions

--- a/core/src/styles/fiori-fundamentals-overrides.scss
+++ b/core/src/styles/fiori-fundamentals-overrides.scss
@@ -84,13 +84,6 @@
   }
 }
 
-//Breadcrumbs
-.y-fd-breadcrumb {
-  a {
-    cursor: pointer;
-  }
-}
-
 //Panel
 .y-fd-panel {
   @extend .fd-panel;

--- a/core/src/styles/fiori-fundamentals-overrides.scss
+++ b/core/src/styles/fiori-fundamentals-overrides.scss
@@ -166,3 +166,7 @@
 a {
   cursor: pointer;
 }
+
+.fd-breadcrumb {
+  margin-bottom: 0px; // fix value of -12px which prevents proper clicking of breadcrumb link on Firefox
+}

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.html
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.html
@@ -1,5 +1,5 @@
 <section class="fd-section">
-  <fd-breadcrumb class="y-fd-breadcrumb">
+  <fd-breadcrumb>
     <fd-breadcrumb-item>
       <a fd-breadcrumb-link (click)="navigateToList()">
         Lambdas

--- a/lambda/src/styles/fiori-fundamentals-overrides.scss
+++ b/lambda/src/styles/fiori-fundamentals-overrides.scss
@@ -187,3 +187,7 @@
 a {
   cursor: pointer;
 }
+
+.fd-breadcrumb {
+  margin-bottom: 0px; // fix value of -12px which prevents proper clicking of breadcrumb link on Firefox
+}

--- a/lambda/src/styles/fiori-fundamentals-overrides.scss
+++ b/lambda/src/styles/fiori-fundamentals-overrides.scss
@@ -58,14 +58,7 @@
   }
 }
 
-//Breadcrumbs
-.y-fd-breadcrumb {
-  a {
-    cursor: pointer;
-  }
-}
 .fd-action-bar {
-
   align-items: center; /* There is a bug in Fiori Fundamentals.
                           In Firefox buttons in `fd-action-bar-actions`
                           are shifted to the bottom.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove href="#" still present in two breadcrumb links
- Remove y-fd-breadcrumb css class, as there is already a global styling for all links
- Remove negative margin bottom from .fd-breadcrumb since Firefox clicking does not work properly

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
