### PR TITLE
Focus function name input if not set

### DIFF
--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.html
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.html
@@ -56,9 +56,13 @@
                 <div class="fd-form__item">
                   <label class="fd-form__label" for="">Function Name * </label>
                   <div class="fd-input-group">
-                    <input type="text" id="input-1" name="function_name" [(ngModel)]="lambda.metadata.name"
-                      [attr.disabled]="mode === 'create' ? null : ''" (keyup)="validatesName()" />
+                    <input type="text" id="input-1" #functionName name="function_name" [(ngModel)]="lambda.metadata.name"
+                      [ngClass]="{'is-invalid': isFunctionNameInvalid, 'is-warning': isFunctionNameEmpty}"
+                      [attr.disabled]="mode === 'create' ? null : ''" (keyup)="validatesName()" (focusout)="validatesName()" />
                   </div>
+                  <fd-form-message [type]="'warning'" *ngIf="isFunctionNameEmpty">
+                    a function name must be specified
+                  </fd-form-message>
                   <fd-form-message [type]="'error'" *ngIf="isFunctionNameInvalid">
                     Invalid name: must consist of lower case alphanumeric
                     characters or '-', start with an alphabetic character, and

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.scss
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.scss
@@ -95,6 +95,10 @@ div[hidden] { display: none; }
   }
 }
 
+input[type=text]:focus{
+  box-shadow: 0 0 0 0px var(--fd-color-action-focus);
+}
+
 
 .labels {
   position: relative;

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
@@ -233,7 +233,6 @@ export class LambdaDetailsComponent implements OnInit, OnDestroy {
               this.editor.setReadOnly(true);
             }
             if (this.lambda.metadata.name === '') {
-              //this.isFunctionNameEmpty = true;
               this.functionName.nativeElement.focus()
             }
 

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
@@ -5,6 +5,7 @@ import {
   ViewChild,
   OnInit,
   OnDestroy,
+  ElementRef,
 } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
@@ -87,6 +88,7 @@ export class LambdaDetailsComponent implements OnInit, OnDestroy {
   public initialLabels: string[];
   public updatedLabels: string[];
 
+  @ViewChild('functionName') functionName: ElementRef;
   @ViewChild('fetchTokenModal') fetchTokenModal: FetchTokenModalComponent;
   @ViewChild('eventTriggerChooserModal')
   eventTriggerChooserModal: EventTriggerChooserComponent;
@@ -129,6 +131,7 @@ export class LambdaDetailsComponent implements OnInit, OnDestroy {
   envVarValue = '';
   isEnvVariableNameInvalid = false;
   isFunctionNameInvalid = false;
+  isFunctionNameEmpty = false;
   isHTTPTriggerAdded = false;
   isHTTPTriggerAuthenticated = true;
   existingHTTPEndpoint: Api;
@@ -229,6 +232,11 @@ export class LambdaDetailsComponent implements OnInit, OnDestroy {
             if (!this.lambda.metadata.name || this.isFunctionNameInvalid) {
               this.editor.setReadOnly(true);
             }
+            if (this.lambda.metadata.name === '') {
+              //this.isFunctionNameEmpty = true;
+              this.functionName.nativeElement.focus()
+            }
+
           }
 
           this.eventActivationsService
@@ -1029,6 +1037,13 @@ export class LambdaDetailsComponent implements OnInit, OnDestroy {
     }
     const regex = /[a-z]([-a-z0-9]*[a-z0-9])?/;
     const found = this.lambda.metadata.name.match(regex);
+    this.isFunctionNameEmpty =
+      this.lambda.metadata.name === ''
+        ? true
+        : false;
+    if (this.isFunctionNameEmpty) {
+      this.isLambdaFormValid = false
+    }
     this.isFunctionNameInvalid =
       (found && found[0] === this.lambda.metadata.name) ||
       this.lambda.metadata.name === ''


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

If you create a new lambda function it is not clear that you have to specify a function name to before you can do anything else

Changes proposed in this pull request:

- Focus the function name input on page init
- show error if you select a different control when the function name is still empty

**Related issue(s)**
kyma-project/kyma#2887