### PR TITLE
Use Dex internal jwks uri when exposing dex-secured APIs

### DIFF
--- a/core/src/app/app.config.ts
+++ b/core/src/app/app.config.ts
@@ -48,7 +48,8 @@ const config = {
   docsModuleUrl: `https://docs.${domain}`,
   logsModuleUrl: `https://log-ui.${domain}`,
   kubeconfigGeneratorUrl: `https://configurations-generator.${domain}/kube-config`,
-  idpLogoutUrl
+  idpLogoutUrl,
+  dexFQDNUri : 'http://dex-service.kyma-system.svc.cluster.local:5556'
 };
 
 // Overwriting values from injected configuration (k8s configMap -> assets/config/config.js)

--- a/core/src/app/content/namespaces/operation/services/service-details/expose-api/expose-api.component.ts
+++ b/core/src/app/content/namespaces/operation/services/service-details/expose-api/expose-api.component.ts
@@ -231,7 +231,7 @@ export class ExposeApiComponent implements OnInit, OnDestroy {
     this.idpPresetsService.getDefaultIdpPreset().subscribe(config => {
       this.defaultAuthConfig = config;
       let hasDex = false;
-      let jwksUri = config.jwks_uri;
+      let jwksUri = AppConfig.dexFQDNUri;
       let issuer = config.issuer;
       this.idpPresetsService
         .getIDPPresets()
@@ -244,7 +244,7 @@ export class ExposeApiComponent implements OnInit, OnDestroy {
             if (!hasDex) {
               this.availablePresets.push({
                 label: 'Dex',
-                jwksUri: config.jwks_uri,
+                jwksUri,
                 issuer: config.issuer
               });
             }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use dex fqdn internal jwks uri when exposing APIs secured by DEX

**Related issue(s)**
https://github.com/kyma-project/console/issues/706