### PR TITLE
create button: avoid save when button state is disabled

### DIFF
--- a/core/src/app/content/settings/applications/create-application-modal/create-application-modal.component.html
+++ b/core/src/app/content/settings/applications/create-application-modal/create-application-modal.component.html
@@ -34,7 +34,7 @@
     </fd-modal-body>
     <fd-modal-footer>
       <button fd-button [options]="'light'" (click)="close()">Cancel</button>
-      <button fd-button [options]="'main'" [state]="!isReadyToCreate() ? 'disabled' : ''" (click)="isReadyToCreate() && save()"
+      <button fd-button [options]="'main'" [disabled]="!isReadyToCreate()" [state]="!isReadyToCreate() ? 'disabled' : ''" (click)="save()"
         [attr.data-e2e-id]="'create-button'">
         Create
       </button>

--- a/core/src/app/content/settings/applications/create-application-modal/create-application-modal.component.html
+++ b/core/src/app/content/settings/applications/create-application-modal/create-application-modal.component.html
@@ -34,7 +34,7 @@
     </fd-modal-body>
     <fd-modal-footer>
       <button fd-button [options]="'light'" (click)="close()">Cancel</button>
-      <button fd-button [options]="'main'" [state]="!isReadyToCreate() ? 'disabled' : ''" (click)="save()"
+      <button fd-button [options]="'main'" [state]="!isReadyToCreate() ? 'disabled' : ''" (click)="isReadyToCreate() && save()"
         [attr.data-e2e-id]="'create-button'">
         Create
       </button>

--- a/core/src/app/content/settings/idp-presets/create-preset-modal/create-preset-modal.component.html
+++ b/core/src/app/content/settings/idp-presets/create-preset-modal/create-preset-modal.component.html
@@ -40,7 +40,8 @@
       <button fd-button 
         [options]="'main'"
         [state]="!isReadyToCreate() ? 'disabled' : ''"
-        (click)="isReadyToCreate() && save()">
+        [disabled]="!isReadyToCreate()"
+        (click)="save()">
         Create
       </button>
     </fd-modal-footer>

--- a/core/src/app/content/settings/idp-presets/create-preset-modal/create-preset-modal.component.html
+++ b/core/src/app/content/settings/idp-presets/create-preset-modal/create-preset-modal.component.html
@@ -40,7 +40,7 @@
       <button fd-button 
         [options]="'main'"
         [state]="!isReadyToCreate() ? 'disabled' : ''"
-        (click)="save()">
+        (click)="isReadyToCreate() && save()">
         Create
       </button>
     </fd-modal-footer>


### PR DESCRIPTION
save is not triggered when clicking _create_ on incomplete form.