### PR TITLE
Amend empty state handling in bound services and events modal

### DIFF
--- a/core/src/app/content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component.html
+++ b/core/src/app/content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component.html
@@ -7,13 +7,11 @@
     (click)="$event.stopPropagation()"
   >
     <fd-modal-header
-      >Bound Service Classes in '{{ namespaceName }}'</fd-modal-header
+      >Services & Events bound to '{{ namespaceName }}'</fd-modal-header
     >
     <fd-modal-body class="">
       <div
-        *ngIf="
-          application && application.services && application.services.length > 0
-        "
+        *ngIf="applicationHasAnyServices; else noServicesHint"
         fd-form-item
       >
         <fd-list class="y-fd-list--no-hover y-fd-list-group__item--no-padding y-fd-list--bottom-margin">
@@ -65,6 +63,9 @@
           
         </fd-list>
       </div>
+      <ng-template #noServicesHint>
+        <p class="fd-has-font-style-italic">This binding doesn't enable any Service or Events.</p>
+      </ng-template>
     </fd-modal-body>
     <fd-modal-footer>
       <button fd-button [fdType]="'main'" (click)="close()">

--- a/core/src/app/content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component.html
+++ b/core/src/app/content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component.html
@@ -11,7 +11,7 @@
     >
     <fd-modal-body class="">
       <div
-        *ngIf="applicationHasAnyServices; else noServicesHint"
+        *ngIf="applicationHasAnyServices && namespaceHasAnyServicesBound; else noServicesHint"
         fd-form-item
       >
         <fd-list class="y-fd-list--no-hover y-fd-list-group__item--no-padding y-fd-list--bottom-margin">
@@ -60,7 +60,7 @@
               </fd-list-action>
             </li>
           </ng-container>
-          
+
         </fd-list>
       </div>
       <ng-template #noServicesHint>

--- a/core/src/app/content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component.ts
+++ b/core/src/app/content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component.ts
@@ -32,6 +32,14 @@ export class BindingsDetailsModalComponent {
     private modalService: ModalService
   ) {}
 
+  get applicationHasAnyServices(): boolean {
+    return (
+      this.application &&
+      this.application.services &&
+      this.application.services.length > 0
+    );
+  }
+
   public show(initialNamespace) {
     this.namespaceName = initialNamespace;
     this.route.params.subscribe(params => {

--- a/core/src/app/content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component.ts
+++ b/core/src/app/content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component.ts
@@ -112,4 +112,11 @@ export class BindingsDetailsModalComponent {
   hasType(entries, type) {
     return _some(entries, { type });
   }
+
+  get namespaceHasAnyServicesBound(): boolean {
+    return (
+      this.selectedApplicationsState &&
+      this.selectedApplicationsState.length > 0
+    );
+  }
 }

--- a/core/src/app/content/settings/applications/application-details/create-bindings-modal/create-binding-modal.component.html
+++ b/core/src/app/content/settings/applications/application-details/create-bindings-modal/create-binding-modal.component.html
@@ -59,17 +59,9 @@
       </div>
       <div fd-form-item>
         <fd-form-label>Services & Events *</fd-form-label>
-        <fd-toggle [size]="'s'" [(ngModel)]="allServices">Select all</fd-toggle>
+        <fd-toggle [size]="'s'" [(ngModel)]="allServices" *ngIf="applicationHasAnyServices">Select all</fd-toggle>
       </div>
-      <div
-        fd-form-item
-        *ngIf="
-          !allServices &&
-          application &&
-          application.services &&
-          application.services.length > 0
-        "
-      >
+      <div fd-form-item *ngIf="!allServices && applicationHasAnyServices; else noServicesHint">
         <fd-list
           class="y-fd-list--no-hover y-fd-list-group__item--no-padding y-fd-list--bottom-margin"
         >
@@ -120,6 +112,9 @@
           </li>
         </fd-list>
       </div>
+      <ng-template #noServicesHint>
+        <p class="fd-has-color-text-4 fd-has-margin-bottom-small">This Application doesn't expose any Service or Events.</p>
+      </ng-template>
     </fd-modal-body>
     <fd-modal-footer>
       <button

--- a/core/src/app/content/settings/applications/application-details/create-bindings-modal/create-binding-modal.component.ts
+++ b/core/src/app/content/settings/applications/application-details/create-bindings-modal/create-binding-modal.component.ts
@@ -42,6 +42,14 @@ export class CreateBindingsModalComponent {
     this.applicationBindingService = applicationBindingService;
   }
 
+  get applicationHasAnyServices(): boolean {
+    return (
+      this.application &&
+      this.application.services &&
+      this.application.services.length
+    );
+  }
+
   public show() {
     this.route.params.subscribe(params => {
       const applicationId = params['id'];

--- a/core/src/app/content/settings/applications/application-details/edit-bindings-modal/edit-binding-modal.component.html
+++ b/core/src/app/content/settings/applications/application-details/edit-bindings-modal/edit-binding-modal.component.html
@@ -12,17 +12,9 @@
     <fd-modal-body>
       <div fd-form-item>
         <fd-form-label>Services & Events *</fd-form-label>
-        <fd-toggle [size]="'s'" [(ngModel)]="allServices">Select all</fd-toggle>
+        <fd-toggle [size]="'s'" [(ngModel)]="allServices" *ngIf="applicationHasAnyServices">Select all</fd-toggle>
       </div>
-      <div
-        *ngIf="
-          !allServices &&
-          application &&
-          application.services &&
-          application.services.length > 0
-        "
-        fd-form-item
-      >
+      <div *ngIf="!allServices && applicationHasAnyServices; else noServicesHint" fd-form-item >
         <fd-list
           class="y-fd-list--no-hover y-fd-list-group__item--no-padding y-fd-list--bottom-margin"
         >
@@ -73,6 +65,9 @@
           </li>
         </fd-list>
       </div>
+      <ng-template #noServicesHint>
+        <p class="fd-has-color-text-4 fd-has-margin-bottom-small">This Application doesn't expose any Service or Events.</p>
+      </ng-template>
     </fd-modal-body>
     <fd-modal-footer>
       <button fd-button [fdType]="'main'" (click)="save()">

--- a/core/src/app/content/settings/applications/application-details/edit-bindings-modal/edit-binding-modal.component.ts
+++ b/core/src/app/content/settings/applications/application-details/edit-bindings-modal/edit-binding-modal.component.ts
@@ -38,6 +38,14 @@ export class EditBindingsModalComponent {
     this.applicationBindingService = applicationBindingService;
   }
 
+  get applicationHasAnyServices(): boolean {
+    return (
+      this.application &&
+      this.application.services &&
+      this.application.services.length > 0
+    );
+  }
+
   public show(initialNamespace) {
     this.namespaceName = initialNamespace;
     this.route.params.subscribe(params => {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Reword modal title (Bound Service Classes in"namespace" -> Services & Events Bound to "namespace")
- Show a hint when displaying binding with no service classes
- Hide the toggle and display hint text on both edit and create binding modal
