### PR TITLE
Organize LogUI toggles

### DIFF
--- a/logging/src/app/app.component.spec.ts
+++ b/logging/src/app/app.component.spec.ts
@@ -12,6 +12,7 @@ import {
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { Apollo } from 'apollo-angular';
+import AppAriaDisabled from './search-form/shared/appAriaDisabled.directive';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -24,7 +25,7 @@ describe('AppComponent', () => {
         FormsModule,
         HttpClientModule,
       ],
-      declarations: [AppComponent, SearchFormComponent],
+      declarations: [AppComponent, SearchFormComponent, AppAriaDisabled],
       providers: [SearchService, LuigiContextService, HttpClientModule, Apollo],
     }).compileComponents();
   }));

--- a/logging/src/app/app.component.spec.ts
+++ b/logging/src/app/app.component.spec.ts
@@ -12,7 +12,7 @@ import {
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { Apollo } from 'apollo-angular';
-import AppAriaDisabled from './search-form/shared/appAriaDisabled.directive';
+import { AriaDisabledDirective } from './search-form/shared/appAriaDisabled.directive';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -25,7 +25,7 @@ describe('AppComponent', () => {
         FormsModule,
         HttpClientModule,
       ],
-      declarations: [AppComponent, SearchFormComponent, AppAriaDisabled],
+      declarations: [AppComponent, SearchFormComponent, AriaDisabledDirective],
       providers: [SearchService, LuigiContextService, HttpClientModule, Apollo],
     }).compileComponents();
   }));

--- a/logging/src/app/app.module.ts
+++ b/logging/src/app/app.module.ts
@@ -23,9 +23,10 @@ import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 
 import { AppConfig } from './app.config';
 import { TokenInterceptor } from './auth/token.interceptor';
+import AppAriaDisabled from './search-form/shared/appAriaDisabled.directive';
 
 @NgModule({
-  declarations: [AppComponent, SearchFormComponent],
+  declarations: [AppComponent, SearchFormComponent, AppAriaDisabled],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/logging/src/app/app.module.ts
+++ b/logging/src/app/app.module.ts
@@ -23,10 +23,10 @@ import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 
 import { AppConfig } from './app.config';
 import { TokenInterceptor } from './auth/token.interceptor';
-import AppAriaDisabled from './search-form/shared/appAriaDisabled.directive';
+import { AriaDisabledDirective } from './search-form/shared/appAriaDisabled.directive';
 
 @NgModule({
-  declarations: [AppComponent, SearchFormComponent, AppAriaDisabled],
+  declarations: [AppComponent, SearchFormComponent, AriaDisabledDirective],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/logging/src/app/search-form/search-form.component.html
+++ b/logging/src/app/search-form/search-form.component.html
@@ -72,11 +72,11 @@
           </select>
         </div>
 
-        <div fd-form-item [isInline]="true">
+        <div fd-form-item *ngIf="isHistoricalDataSwitchVisible" [isInline]="true">
           <fd-form-label >
             Show
           </fd-form-label>
-          <label *ngIf="isHistoricalDataSwitchVisible"  fd-form-label for="outdatedLogsToggle">
+          <label fd-form-label for="outdatedLogsToggle">
             <input fd-form-control type="checkbox"  [(ngModel)]="model.showOutdatedLogs"  name="showOutdatedLogs" (change)="onSubmit()" id="outdatedLogsToggle" >
             Outdated logs
           </label>

--- a/logging/src/app/search-form/search-form.component.html
+++ b/logging/src/app/search-form/search-form.component.html
@@ -72,15 +72,17 @@
           </select>
         </div>
 
-        <div *ngIf="isHistoricalDataSwitchVisible" fd-form-item [isInline]="true">
+        <div fd-form-item [isInline]="true">
           <fd-form-label >
-            Historical Logs
+            Show
           </fd-form-label>
-          <label fd-form-label for="outdatedLogsToggle">
+          <label *ngIf="isHistoricalDataSwitchVisible"  fd-form-label for="outdatedLogsToggle">
             <input fd-form-control type="checkbox"  [(ngModel)]="model.showOutdatedLogs"  name="showOutdatedLogs" (change)="onSubmit()" id="outdatedLogsToggle" >
-            Include function's previous versions
+            Outdated logs
           </label>
         </div>
+        
+   
       </fieldset>
 
       <fieldset fd-form-set>
@@ -105,24 +107,33 @@
           </span>
         </div>
 
-        <div fd-form-item [isInline]="true">
-          <div class="fd-form__item fd-form__item--check fd_panel__refresh-toggle">
-            <label class="fd-form__label" for="auto-refresh-toggle">
-                <span class="fd-toggle fd-form__control">
-                    <input
-                        type="checkbox"
-                        checked id="auto-refresh-toggle"
-                        (change)="toggleAutoRefresh($event)"
-                        [disabled]="!canSetAutoRefresh || !searchData.form.valid">
-                    <span class="fd-toggle__switch" role="presentation"></span>
-                </span>
-                Auto refresh
-            </label>
-          </div>
-        </div>
 
         <div fd-form-item [isInline]="true">
-          <button fd-button type="submit" [glyph]="'search'" [options]="'light'" [disabled]="!searchData.form.valid || autoRefreshEnabled">Search</button>
+            <div class="fd-popover">
+                <div class="fd-popover__control">  
+                    <button fd-button type="submit" 
+                    (click)="handleSearchFormClicked($event)"
+                    [glyph]="'search'" 
+                    [options]="'light'"
+                    [appAriaDisabled]="!searchData.form.valid || autoRefreshEnabled" 
+                    (mouseenter)="autoRefreshEnabled? isSearchButtonTooltipOpen = true: null"
+                    (mouseout)="isSearchButtonTooltipOpen = false"
+                    [attr.aria-expanded]="isSearchButtonTooltipOpen" aria-haspopup="true">
+                      Search
+                    </button>
+                </div>
+                <div class="fd-popover__body fd-has-padding-tiny" [attr.aria-hidden]="!isSearchButtonTooltipOpen" >
+                   {{ DISABLED_SEARCH_BUTTON_TOOLTIP }}
+                </div>
+            </div>
+
+          <button fd-button 
+            class="fd-has-margin-left-small"
+            *ngIf="canSetAutoRefresh" 
+            [glyph]="autoRefreshEnabled?'media-pause':'media-play'" 
+            (click)="toggleAutoRefresh()">
+            Auto refresh
+          </button>
         </div>
       </fieldset>
 
@@ -140,28 +151,28 @@
 
 <div class="fd-section" *ngFor="let stream of searchResult.streams">
   <div class="fd-panel">
-  <div class="fd-panel__filters" >
-    Available labels for stream:
-    <ng-container *ngFor="let label of stream.availableLabels">
-      <div class="fd-token y-fd-token y-fd-token--no-close-button" role="button"
-          *ngIf="!isSelectedLabel(label)" (click)="addLabel($event.target.outerText)">
-        {{ label }}
-        </div>
-    </ng-container>
-  </div>
-  <div class="fd-panel__body">
-    <fd-table>
-      <fd-table-header>
-        <th>Timestamp</th>
-        <th>Log</th>
-      </fd-table-header>
-      <fd-table-body>
-        <tr *ngFor="let row of stream.entries">
-          <td class="no-word-break">{{ row.ts }}</td>
-          <td class="word-break">{{ row.line }}</td>
-        </tr>
-      </fd-table-body>
-    </fd-table>
-  </div>
+    <div class="fd-panel__filters" >
+      Available labels for stream:
+      <ng-container *ngFor="let label of stream.availableLabels">
+        <div class="fd-token y-fd-token y-fd-token--no-close-button" role="button"
+            *ngIf="!isSelectedLabel(label)" (click)="addLabel($event.target.outerText)">
+          {{ label }}
+          </div>
+      </ng-container>
+    </div>
+    <div class="fd-panel__body">
+      <fd-table>
+        <fd-table-header>
+          <th>Timestamp</th>
+          <th>Log</th>
+        </fd-table-header>
+        <fd-table-body>
+          <tr *ngFor="let row of stream.entries">
+            <td class="no-word-break">{{ row.ts }}</td>
+            <td class="word-break">{{ row.line }}</td>
+          </tr>
+        </fd-table-body>
+      </fd-table>
+    </div>
   </div>
 </div>

--- a/logging/src/app/search-form/search-form.component.html
+++ b/logging/src/app/search-form/search-form.component.html
@@ -112,7 +112,6 @@
             <div class="fd-popover">
                 <div class="fd-popover__control">  
                     <button fd-button type="submit" 
-                    (click)="handleSearchFormClicked($event)"
                     [glyph]="'search'" 
                     [options]="'light'"
                     [appAriaDisabled]="!searchData.form.valid || autoRefreshEnabled" 

--- a/logging/src/app/search-form/search-form.component.spec.ts
+++ b/logging/src/app/search-form/search-form.component.spec.ts
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 import { ISearchFormData } from './data';
 import { PodsSubscriptonService } from './service/pods-subscription/pods-subscription.service';
 import { Apollo } from 'apollo-angular';
+import AppAriaDisabled from './shared/appAriaDisabled.directive';
 
 const ActivatedRouteMock = {
   queryParams: of({}),
@@ -21,7 +22,7 @@ describe('SearchFormComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SearchFormComponent],
+      declarations: [SearchFormComponent, AppAriaDisabled],
       imports: [HttpClientTestingModule, FundamentalNgxModule, FormsModule],
       providers: [
         SearchService,

--- a/logging/src/app/search-form/search-form.component.spec.ts
+++ b/logging/src/app/search-form/search-form.component.spec.ts
@@ -10,7 +10,7 @@ import { of } from 'rxjs';
 import { ISearchFormData } from './data';
 import { PodsSubscriptonService } from './service/pods-subscription/pods-subscription.service';
 import { Apollo } from 'apollo-angular';
-import AppAriaDisabled from './shared/appAriaDisabled.directive';
+import { AriaDisabledDirective } from './shared/appAriaDisabled.directive';
 
 const ActivatedRouteMock = {
   queryParams: of({}),
@@ -22,7 +22,7 @@ describe('SearchFormComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SearchFormComponent, AppAriaDisabled],
+      declarations: [SearchFormComponent, AriaDisabledDirective],
       imports: [HttpClientTestingModule, FundamentalNgxModule, FormsModule],
       providers: [
         SearchService,

--- a/logging/src/app/search-form/search-form.component.ts
+++ b/logging/src/app/search-form/search-form.component.ts
@@ -17,7 +17,7 @@ import {
   DISABLED_SEARCH_BUTTON_TOOLTIP,
 } from './shared/constants';
 
-import AriaDisabledDirective from './shared/appAriaDisabled.directive';
+import { AriaDisabledDirective } from './shared/appAriaDisabled.directive';
 
 @Component({
   selector: 'app-search-form',
@@ -392,5 +392,4 @@ export class SearchFormComponent implements OnInit, OnDestroy {
       this.refreshResults();
     }
   }
-
 }

--- a/logging/src/app/search-form/search-form.component.ts
+++ b/logging/src/app/search-form/search-form.component.ts
@@ -12,7 +12,12 @@ import { IPod, IPodQueryResponse } from './data/pod-query';
 
 import { PodsSubscriptonService } from './service/pods-subscription/pods-subscription.service';
 
-import { REFRESH_INTERVAL } from './shared/constants';
+import {
+  REFRESH_INTERVAL,
+  DISABLED_SEARCH_BUTTON_TOOLTIP,
+} from './shared/constants';
+
+import AriaDisabledDirective from './shared/appAriaDisabled.directive';
 
 @Component({
   selector: 'app-search-form',
@@ -67,6 +72,8 @@ export class SearchFormComponent implements OnInit, OnDestroy {
   public isHistoricalDataSwitchVisible = false;
 
   private podsForFunction: IPod[];
+  public isSearchButtonTooltipOpen = false;
+  readonly DISABLED_SEARCH_BUTTON_TOOLTIP = DISABLED_SEARCH_BUTTON_TOOLTIP;
 
   constructor(
     private route: ActivatedRoute,
@@ -130,8 +137,7 @@ export class SearchFormComponent implements OnInit, OnDestroy {
       if (this.autoRefreshEnabled) {
         this.runPollingSubscription();
       }
-    }
-    else {
+    } else {
       this.canSetAutoRefresh = false;
     }
   }
@@ -346,37 +352,38 @@ export class SearchFormComponent implements OnInit, OnDestroy {
     });
   }
 
-  onToTimeChanged(event: { target: { value: string; }; }) {
+  onToTimeChanged(event: { target: { value: string } }) {
     if (event.target.value === 'now') {
       this.canSetAutoRefresh = true;
       if (this.autoRefreshEnabled) {
         this.runPollingSubscription();
       }
-    }
-    else {
+    } else {
       this.canSetAutoRefresh = false;
       this.stopPollingSubscription();
     }
   }
 
-  toggleAutoRefresh(e) {
-    this.autoRefreshEnabled = e.target.checked;
+  toggleAutoRefresh(e?) {
+    this.autoRefreshEnabled =
+      e === undefined ? !this.autoRefreshEnabled : e.target.checked;
     if (this.autoRefreshEnabled) {
       this.tryRefreshResults(); // refresh so that user immediately can see new logs
       this.runPollingSubscription();
-    }
-    else {
+    } else {
       this.stopPollingSubscription();
     }
   }
 
   private runPollingSubscription() {
-    this.pollingSubscription = interval(REFRESH_INTERVAL).subscribe(() => this.tryRefreshResults());
+    this.pollingSubscription = interval(REFRESH_INTERVAL).subscribe(() =>
+      this.tryRefreshResults(),
+    );
   }
 
   private stopPollingSubscription() {
     if (this.pollingSubscription && !this.pollingSubscription.closed) {
-      this.pollingSubscription.unsubscribe(); 
+      this.pollingSubscription.unsubscribe();
     }
   }
 

--- a/logging/src/app/search-form/search-form.component.ts
+++ b/logging/src/app/search-form/search-form.component.ts
@@ -14,7 +14,6 @@ import { PodsSubscriptonService } from './service/pods-subscription/pods-subscri
 
 import {
   REFRESH_INTERVAL,
-  DISABLED_SEARCH_BUTTON_TOOLTIP,
 } from './shared/constants';
 
 import { AriaDisabledDirective } from './shared/appAriaDisabled.directive';
@@ -73,7 +72,7 @@ export class SearchFormComponent implements OnInit, OnDestroy {
 
   private podsForFunction: IPod[];
   public isSearchButtonTooltipOpen = false;
-  readonly DISABLED_SEARCH_BUTTON_TOOLTIP = DISABLED_SEARCH_BUTTON_TOOLTIP;
+  readonly DISABLED_SEARCH_BUTTON_TOOLTIP = `The results are updated automatically`;
 
   constructor(
     private route: ActivatedRoute,

--- a/logging/src/app/search-form/shared/appAriaDisabled.directive.ts
+++ b/logging/src/app/search-form/shared/appAriaDisabled.directive.ts
@@ -11,7 +11,7 @@ import {
 @Directive({
   selector: '[appAriaDisabled]',
 })
-class AriaDisabledDirective implements OnChanges{
+export class AriaDisabledDirective implements OnChanges {
   constructor(private _elRef: ElementRef, private _renderer: Renderer2) {}
   @Input('appAriaDisabled') isDisabled: boolean;
 
@@ -21,7 +21,7 @@ class AriaDisabledDirective implements OnChanges{
         this._elRef.nativeElement,
         'aria-disabled',
         this.isDisabled.toString(),
-      ); // set the directive input as 'aria-disabled' value 
+      ); // set the directive input as 'aria-disabled' value
     }
   }
 
@@ -32,5 +32,3 @@ class AriaDisabledDirective implements OnChanges{
     }
   }
 }
-
-export default AriaDisabledDirective;

--- a/logging/src/app/search-form/shared/appAriaDisabled.directive.ts
+++ b/logging/src/app/search-form/shared/appAriaDisabled.directive.ts
@@ -1,22 +1,23 @@
 import {
   Directive,
   ElementRef,
-  Renderer,
   Input,
   SimpleChanges,
   HostListener,
+  Renderer2,
+  OnChanges,
 } from '@angular/core';
 
 @Directive({
   selector: '[appAriaDisabled]',
 })
-class AriaDisabledDirective {
-  constructor(private _elRef: ElementRef, private _renderer: Renderer) {}
+class AriaDisabledDirective implements OnChanges{
+  constructor(private _elRef: ElementRef, private _renderer: Renderer2) {}
   @Input('appAriaDisabled') isDisabled: boolean;
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.isDisabled) {
-      this._renderer.setElementAttribute(
+      this._renderer.setAttribute(
         this._elRef.nativeElement,
         'aria-disabled',
         this.isDisabled.toString(),

--- a/logging/src/app/search-form/shared/appAriaDisabled.directive.ts
+++ b/logging/src/app/search-form/shared/appAriaDisabled.directive.ts
@@ -1,0 +1,35 @@
+import {
+  Directive,
+  ElementRef,
+  Renderer,
+  Input,
+  SimpleChanges,
+  HostListener,
+} from '@angular/core';
+
+@Directive({
+  selector: '[appAriaDisabled]',
+})
+class AriaDisabledDirective {
+  constructor(private _elRef: ElementRef, private _renderer: Renderer) {}
+  @Input('appAriaDisabled') isDisabled: boolean;
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.isDisabled) {
+      this._renderer.setElementAttribute(
+        this._elRef.nativeElement,
+        'aria-disabled',
+        this.isDisabled.toString(),
+      ); // set the directive input as 'aria-disabled' value 
+    }
+  }
+
+  @HostListener('click', ['$event'])
+  onClick(e) {
+    if (this.isDisabled) {
+      e.preventDefault(); // do NOT perform click event if element is disabled (behave like HTML 'disabled' attribute)
+    }
+  }
+}
+
+export default AriaDisabledDirective;

--- a/logging/src/app/search-form/shared/constants.ts
+++ b/logging/src/app/search-form/shared/constants.ts
@@ -1,2 +1,1 @@
 export const REFRESH_INTERVAL = 2 * 1000; // ms
-export const DISABLED_SEARCH_BUTTON_TOOLTIP= `The results are updated automatically`

--- a/logging/src/app/search-form/shared/constants.ts
+++ b/logging/src/app/search-form/shared/constants.ts
@@ -1,1 +1,2 @@
 export const REFRESH_INTERVAL = 2 * 1000; // ms
+export const DISABLED_SEARCH_BUTTON_TOOLTIP= `The results are updated automatically`


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Changes proposed in this pull request:

- Add "Auto refresh" button next to the "Search" button
- Display a tooltip on "Search" button to explain its disabled state when auto refresh is on
- Add new input form item - _"Show" > "Outdated logs"_ only for Lambda logs

### "I can see an **error** when I pause and play auto refresh on freshly opened non-lambda LogUI"
Don't worry ;) There's a bug in the whole search mechanizm - _search query_ field is not validated. When you play auto refresh back (after it was paused), a single form submit is performed (like you also clicked "Search") which makes the backend throw the error because _search query_ is empty.

