### PR TITLE
Fix create metadata definition bug

### DIFF
--- a/compass/src/components/Labels/CreateLabelModal/CreateLabelModal.container.js
+++ b/compass/src/components/Labels/CreateLabelModal/CreateLabelModal.container.js
@@ -1,11 +1,12 @@
 import { graphql, compose } from 'react-apollo';
-import { GET_LABEL_NAMES, CREATE_LABEL } from './../gql';
+import { CREATE_LABEL } from './../gql';
+import { GET_LABEL_DEFINITIONS } from '../../MetadataDefinitions/gql';
 import { SEND_NOTIFICATION } from '../../../gql';
 
 import CreateLabelModal from './CreateLabelModal.component';
 
 export default compose(
-  graphql(GET_LABEL_NAMES, {
+  graphql(GET_LABEL_DEFINITIONS, {
     name: 'labelNamesQuery',
   }),
   graphql(CREATE_LABEL, {

--- a/compass/src/components/Labels/gql.js
+++ b/compass/src/components/Labels/gql.js
@@ -1,13 +1,5 @@
 import gql from 'graphql-tag';
 
-export const GET_LABEL_NAMES = gql`
-  query allLabels {
-    labelDefinitions {
-      key
-    }
-  }
-`;
-
 export const CREATE_LABEL = gql`
   mutation createLabelDefinition($in: LabelDefinitionInput!) {
     createLabelDefinition(in: $in) {


### PR DESCRIPTION
**Description**

When user creates new metadata definition, it succeeds, but app crashes in a few seconds.

Changes proposed in this pull request:

- Reuse _get labels_ query
