### PR TITLE
Logs in modal window for pods and lambdas fixed

### DIFF
--- a/core/src/app/content/namespaces/operation/pods/pods.component.ts
+++ b/core/src/app/content/namespaces/operation/pods/pods.component.ts
@@ -8,6 +8,7 @@ import { PodsHeaderRendererComponent } from './pods-header-renderer/pods-header-
 
 import * as luigiClient from '@kyma-project/luigi-client';
 import { GraphQLClientService } from 'shared/services/graphql-client-service';
+import { identifierModuleUrl } from '@angular/compiler';
 
 @Component({
   templateUrl: '../kubernetes-element-list.component.html'
@@ -85,10 +86,17 @@ export class PodsComponent extends AbstractGraphqlElementListComponent
   getEntryEventHandler(): any {
     const handler = super.getEntryEventHandler();
     handler.showLogs = (entry: any) => {
+      const nodeParams = { namespace: this.currentNamespaceId, splitViewMode: 'true' };
+      if(entry.labels && entry.labels.app) {
+        nodeParams['app'] = entry.labels.app;
+      }
+      if(entry.labels && entry.labels['pod-template-hash']) {
+        nodeParams['pod_template_hash'] = entry.labels['pod-template-hash'];
+      }
       luigiClient
         .linkManager()
-        .withParams({ app: entry.labels.app, namespace: this.currentNamespaceId, splitViewMode: 'true' })
-        .openAsModal('/home/cmf-logs');
+        .withParams(nodeParams)
+        .openAsModal('/home/cmf-logs', {title:' '});
     };
     return handler;
   }

--- a/core/src/app/content/namespaces/operation/pods/pods.component.ts
+++ b/core/src/app/content/namespaces/operation/pods/pods.component.ts
@@ -8,7 +8,7 @@ import { PodsHeaderRendererComponent } from './pods-header-renderer/pods-header-
 
 import * as luigiClient from '@kyma-project/luigi-client';
 import { GraphQLClientService } from 'shared/services/graphql-client-service';
-import { identifierModuleUrl } from '@angular/compiler';
+
 
 @Component({
   templateUrl: '../kubernetes-element-list.component.html'

--- a/core/src/app/content/namespaces/operation/pods/pods.component.ts
+++ b/core/src/app/content/namespaces/operation/pods/pods.component.ts
@@ -86,17 +86,11 @@ export class PodsComponent extends AbstractGraphqlElementListComponent
   getEntryEventHandler(): any {
     const handler = super.getEntryEventHandler();
     handler.showLogs = (entry: any) => {
-      const nodeParams = { namespace: this.currentNamespaceId, splitViewMode: 'true' };
-      if(entry.labels && entry.labels.app) {
-        nodeParams['app'] = entry.labels.app;
-      }
-      if(entry.labels && entry.labels['pod-template-hash']) {
-        nodeParams['pod_template_hash'] = entry.labels['pod-template-hash'];
-      }
+      const nodeParams = { namespace: this.currentNamespaceId, splitViewMode: 'true', instance: entry.name };
       luigiClient
         .linkManager()
         .withParams(nodeParams)
-        .openAsModal('/home/cmf-logs', {title:' '});
+        .openAsModal('/home/cmf-logs', {title: `Logs from ${entry.name}`});
     };
     return handler;
   }

--- a/core/src/app/content/namespaces/operation/pods/pods.component.ts
+++ b/core/src/app/content/namespaces/operation/pods/pods.component.ts
@@ -87,7 +87,7 @@ export class PodsComponent extends AbstractGraphqlElementListComponent
     handler.showLogs = (entry: any) => {
       luigiClient
         .linkManager()
-        .withParams({ pod: entry.name, namespace: this.currentNamespaceId })
+        .withParams({ app: entry.labels.app, namespace: this.currentNamespaceId, splitViewMode: 'true' })
         .openAsModal('/home/cmf-logs');
     };
     return handler;

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
@@ -996,7 +996,7 @@ export class LambdaDetailsComponent implements OnInit, OnDestroy {
           function: this.lambda.metadata.name,
           namespace: this.namespace,
           container_name: this.lambda.metadata.name,
-          splitViewMode: 'true',
+          compact: 'true',
         })
         .openAsSplitView('/home/cmf-logs',{title: 'Logs', size: 40, collapsed: true});
     }

--- a/lambda/src/app/lambdas/list/lambdas-entry-renderer/lambdas-entry-renderer.component.ts
+++ b/lambda/src/app/lambdas/list/lambdas-entry-renderer/lambdas-entry-renderer.component.ts
@@ -27,7 +27,7 @@ export class LambdasEntryRendererComponent extends AbstractTableEntryRendererCom
   ];
 
   constructor(
-    private appRef: ApplicationRef, 
+    private appRef: ApplicationRef,
     protected injector: Injector,
     private luigiClientService: LuigiClientService
   ) {
@@ -42,17 +42,14 @@ export class LambdasEntryRendererComponent extends AbstractTableEntryRendererCom
 
   ngOnInit() {
     this.showMetricsColumn = this.luigiClientService.hasBackendModule('grafana');
+    const lokiInstalled = this.luigiClientService.hasBackendModule('loki');
 
-    LuigiClient.linkManager().pathExists('/home/cmf-logs').then(exists => {
-      if (exists) {
-        {
-          this.actions.push({
-            function: 'showLogs',
-            name: 'Show Logs'
-          });
-        }
-      }
-    });
+    if (lokiInstalled) {
+      this.actions.push({
+        function: 'showLogs',
+        name: 'Show Logs'
+      });
+    }
   }
 
   getTrigger(entry) {

--- a/lambda/src/app/lambdas/list/lambdas.component.ts
+++ b/lambda/src/app/lambdas/list/lambdas.component.ts
@@ -136,7 +136,7 @@ export class LambdasComponent extends GenericTableComponent
             namespace: this.environment,
             splitViewMode: 'true',
           })
-          .openAsModal('/home/cmf-logs');
+          .openAsModal('/home/cmf-logs', {title:' '});
       },
     };
   }

--- a/lambda/src/app/lambdas/list/lambdas.component.ts
+++ b/lambda/src/app/lambdas/list/lambdas.component.ts
@@ -134,6 +134,7 @@ export class LambdasComponent extends GenericTableComponent
           .withParams({
             function: entry.metadata.name,
             namespace: this.environment,
+            splitViewMode: 'true',
           })
           .openAsModal('/home/cmf-logs');
       },

--- a/lambda/src/app/lambdas/list/lambdas.component.ts
+++ b/lambda/src/app/lambdas/list/lambdas.component.ts
@@ -136,7 +136,7 @@ export class LambdasComponent extends GenericTableComponent
             namespace: this.environment,
             splitViewMode: 'true',
           })
-          .openAsModal('/home/cmf-logs', {title:' '});
+          .openAsModal('/home/cmf-logs', {title: `Logs from ${entry.metadata.name}`});
       },
     };
   }

--- a/logging/src/components/LogsContainer.js
+++ b/logging/src/components/LogsContainer.js
@@ -28,6 +28,7 @@ export default function LogsContainer() {
     return labels;
   }
 
+  const isCompactMode = isCompact();
   const readOnlyLabels = getLabelValuesFromViewParams();
 
   return (
@@ -36,7 +37,7 @@ export default function LogsContainer() {
       queryTransformService={queryTransformService}
       podsSubscriptionService={podsSubscriptionService}
       readonlyLabels={readOnlyLabels}
-      isCompact={isCompact()}
+      isCompact={isCompactMode}
     />
   );
 }

--- a/logging/src/components/Shared/ResultsOptionsDropdown/ResultsOptionsDropdown.js
+++ b/logging/src/components/Shared/ResultsOptionsDropdown/ResultsOptionsDropdown.js
@@ -15,7 +15,7 @@ export default function ResultOptionsDropdown() {
 
   const PopoverContent = () => (
     <FormSet id="result-options">
-      <FormItem className="fd-has-margin-small">
+      {/* <FormItem className="fd-has-margin-small">
         <FormInput
           type="checkbox"
           id="previous-logs"
@@ -28,7 +28,7 @@ export default function ResultOptionsDropdown() {
         >
           logs of previous lambda version
         </FormLabel>
-      </FormItem>
+      </FormItem> */}
       <FormItem className="fd-has-margin-small">
         <FormInput
           type="checkbox"

--- a/logging/src/constants.js
+++ b/logging/src/constants.js
@@ -25,6 +25,7 @@ export const LOG_LABEL_CATEGORIES = [
   'job',
   'release',
   'stream',
+  'instance',
 ];
 
 export const LOG_REFRESH_INTERVAL = 2000; // ms


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- append `splitView` node param to enforce compact view for logs in modals (pods & lambda list)
- add `Show logs` menu entry  basing on `loki` BM existance
- fix log labels for pods 

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/4711
