### PR TITLE
Fix split mode when loki not installed

### DIFF
--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.html
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.html
@@ -298,7 +298,7 @@
           </fd-panel-head>
           <fd-panel-actions>
             <ng-container *ngIf="allEventTriggers.length > 0">
-                <div class="fd-dropdown fd-has-display-block" (clickOutside)="toggleDropDown(false)" clickOutsideEvents="click,mousedown" excludeBeforeClick="true">
+                <div class="fd-dropdown fd-has-display-inline-block" (clickOutside)="toggleDropDown(false)" clickOutsideEvents="click,mousedown" excludeBeforeClick="true">
                   <div class="fd-popover fd-has-display-block fd-popover--right">
                     <div class="fd-popover__control">
                       <button class="fd-dropdown__control y-fd-dropdown__control fd-button fd-has-padding-none" aria-controls="nNJnB279"

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
@@ -984,7 +984,9 @@ export class LambdaDetailsComponent implements OnInit, OnDestroy {
     .linkManager()
     .pathExists('/home/cmf-logs')
     .then(exists => {
-      this.showLogs()
+      if(exists){
+        this.showLogs();
+      }
     });
   }
 

--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
@@ -1418,11 +1418,15 @@ export class LambdaDetailsComponent implements OnInit, OnDestroy {
   }
 
   collapseSplitView(){
-    this.logsViewHandle.collapse();
+    if(this.logsViewHandle){
+      this.logsViewHandle.collapse();
+    }
   }
 
   expandSplitView(){
-    this.logsViewHandle.expand();
+    if(this.logsViewHandle){
+      this.logsViewHandle.expand();
+    }
   }
 
   showNotification(notificationData: INotificationData, timeout?: number) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Do not render split view mode container in case loki not installed

**Related issue(s)**
https://github.com/kyma-project/console/issues/1302