### PR TITLE
Navigate to namespace details after namespace creation

### DIFF
--- a/core-ui/src/components/CreateNamespaceForm/CreateNamespaceForm.js
+++ b/core-ui/src/components/CreateNamespaceForm/CreateNamespaceForm.js
@@ -240,7 +240,7 @@ const CreateNamespaceForm = ({
 
   useEffect(() => {
     const element = formValues.name.current;
-    setTimeout(() => {
+    setImmediate(() => {
       if (element && typeof element.focus === 'function') element.focus();
     });
   }, [formValues.name]);
@@ -340,8 +340,7 @@ const CreateNamespaceForm = ({
         err.additionalRequestFailed = true;
         throw err;
       }
-
-      onCompleted('Success', `Namespace ${namespaceData.name} created.`);
+      onCompleted(namespaceData.name);
     } catch (e) {
       if (e.additionalRequestFailed) {
         onError(
@@ -411,7 +410,7 @@ CreateNamespaceForm.propTypes = {
   isValid: PropTypes.bool,
   onChange: PropTypes.func,
   onError: PropTypes.func, // args: title(string), message(string)
-  onCompleted: PropTypes.func, // args: title(string), message(string)
+  onCompleted: PropTypes.func, // args: namespaceName(string)
   performManualSubmit: PropTypes.func, // no args
 };
 

--- a/core-ui/src/components/NamespaceList/NamespacesListHeader/NamespacesListHeader.js
+++ b/core-ui/src/components/NamespaceList/NamespacesListHeader/NamespacesListHeader.js
@@ -14,6 +14,12 @@ NamespacesListHeader.propTypes = {
   setLabelFilters: PropTypes.func.isRequired,
 };
 
+function navigateToNamespaceDetails(namespaceName) {
+  LuigiClient.linkManager().navigate(
+    `/home/namespaces/${namespaceName}/details`,
+  );
+}
+
 export default function NamespacesListHeader({
   labelFilters,
   updateSearchPhrase,
@@ -38,7 +44,12 @@ export default function NamespacesListHeader({
           title="Add new namespace"
           button={{ text: 'Add new namespace', glyph: 'add' }}
           id="add-namespace-modal"
-          renderForm={props => <CreateNamespaceForm {...props} />}
+          renderForm={props => (
+            <CreateNamespaceForm
+              {...props}
+              onCompleted={navigateToNamespaceDetails}
+            />
+          )}
           opened={opened}
         />
       </div>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add automatic navigation to namespace details
- Use setImmediate in place of setTimeout(0)

**Related issue(s)**
[Kyma](https://github.com/kyma-project/kyma/pull/6202)