### PR TITLE
Scenario Details View (no longer) crashes with minified react error

### DIFF
--- a/compass/src/components/Scenarios/ScenarioDetails/ScenarioApplications/ScenarioApplications.component.js
+++ b/compass/src/components/Scenarios/ScenarioDetails/ScenarioApplications/ScenarioApplications.component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LuigiClient from '@kyma-project/luigi-client';
 
-import GenericList from 'react-shared';
+import { GenericList } from 'react-shared';
 import { Panel } from '@kyma-project/react-components';
 import AssignEntityToScenarioModal from './../shared/AssignEntityToScenarioModal/AssignApplicationsToScenarioModal.container';
 import unassignScenarioHandler from './../shared/unassignScenarioHandler';

--- a/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/ScenarioRuntimes.component.js
+++ b/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/ScenarioRuntimes.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import GenericList from 'react-shared';
+import { GenericList } from 'react-shared';
 import { Panel } from '@kyma-project/react-components';
 import AssignEntityToScenarioModal from '../shared/AssignEntityToScenarioModal/AssignRuntimesToScenarioModal.container';
 import unassignScenarioHandler from '../shared/unassignScenarioHandler';


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change GenericList's default to named import in ScenarioRuntimes and ScenarioApplications

**Related issue(s)**
[Kyma](https://github.com/kyma-project/kyma/pull/6297)
[Compass](https://github.com/kyma-project/kyma/pull/6297)
