### PR TITLE
Meta Information Details view (no longer) crashes for definitions with `/` in the label key

### DIFF
--- a/compass/src/App.component.js
+++ b/compass/src/App.component.js
@@ -123,17 +123,21 @@ class App extends React.Component {
             <Route
               path="/metadatadefinition/:definitionKey"
               exact
-              render={({ match }) => (
-                <MetadataDefinitionDetails
-                  definitionKey={match.params.definitionKey}
-                />
-              )}
+              render={RoutedMetadataDefinitionDetails}
             />
           </Switch>
         </Router>
       </div>
     );
   }
+}
+
+function RoutedMetadataDefinitionDetails({ match }) {
+  return (
+    <MetadataDefinitionDetails
+      definitionKey={decodeURIComponent(match.params.definitionKey)}
+    />
+  );
 }
 
 function RoutedScenarioDetails({ match }) {

--- a/compass/src/components/MetadataDefinitions/MetadataDefinitions.component.js
+++ b/compass/src/components/MetadataDefinitions/MetadataDefinitions.component.js
@@ -11,7 +11,9 @@ class MetadataDefinitions extends React.Component {
   rowRenderer = labelDef => [
     <span
       onClick={() =>
-        LuigiClient.linkManager().navigate(`details/${labelDef.key}`)
+        LuigiClient.linkManager().navigate(
+          `details/${encodeURIComponent(labelDef.key)}`,
+        )
       }
       className="link"
     >


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use `URIComponent` methods to pass the metadata-definition safely. In case of applications, runtimes and scenarios no action is needed, as they already cannot contain URL-breaking characters.

**Related issue(s)**