### PR TITLE
add curl to ui-tests Docker image

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
     libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
     libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-    ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget && \
+    ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget curl && \
     apt-get clean && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
 ENV NODE_PATH="/usr/local/share/.config/yarn/global/node_modules:${NODE_PATH}"


### PR DESCRIPTION
**Description**
Add `curl` binary to ui-tests Docker image
This is necessary in order to run the tests in Azure environment - See https://github.com/kyma-project/kyma/issues/4719

Changes proposed in this pull request:

- Add `curl` binary to ui-tests Docker image

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/4719
