### PR TITLE
Service Instance Details view not refetching Instance data

### DIFF
--- a/service-catalog-ui/instances/src/store/index.js
+++ b/service-catalog-ui/instances/src/store/index.js
@@ -41,7 +41,12 @@ export function createApolloClient() {
     link,
     cache: new InMemoryCache(),
     defaultOptions: {
-      fetchPolicy: 'no-cache',
+      watchQuery: {
+        fetchPolicy: 'no-cache',
+      },
+      query: {
+        fetchPolicy: 'no-cache',
+      },
     },
   });
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use no cache policy on both `watchQuery` and `query`.

Used DoD scenario:

1. Add any instance. You'll be redirected into details page, with _provisioning_ state.
2. Move back to instances list. New instance should be listed, along with its _running_ state (I used `[Preview] SAP Commerce Cloud - Mock`).
3. Move to new instance details again. Without changed cache policy, it will be still in _provisioning_ state, even though on the list it's already _running_.

**Related issue(s)**

