### PR TITLE
Host value split in half in API Rule Header

### DIFF
--- a/core-ui/src/components/ApiRules/ApiRuleDetails/ApiRuleDetails.js
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/ApiRuleDetails.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/react-hooks';
 import LuigiClient from '@kyma-project/luigi-client';
-import { LayoutGrid, Panel, Button } from 'fundamental-react';
+import { LayoutGrid, Panel, Button, Icon } from 'fundamental-react';
 
 import AccessStrategy from '../AccessStrategy/AccessStrategy';
 import { GET_API_RULE } from '../../../gql/queries';
@@ -93,6 +93,14 @@ function navigateToEditView(apiRuleName) {
 }
 
 function ApiRuleDetailsHeader({ data }) {
+  const host = `https://${data.service.host}`;
+  const hostCaption = (
+    <a href={host} target="_blank" rel="noopener noreferrer">
+      {host}
+      <Icon glyph="inspect" size="s" className="fd-has-margin-left-tiny" />
+    </a>
+  );
+
   return (
     <PageHeader
       title={data.name}
@@ -104,11 +112,11 @@ function ApiRuleDetailsHeader({ data }) {
         </>
       }
     >
-      <PageHeader.Column title="Host">
-        <CopiableText text={`https://${data.service.host}`} />
-      </PageHeader.Column>
       <PageHeader.Column title="Service">
         {`${data.service.name} (port: ${data.service.port})`}
+      </PageHeader.Column>
+      <PageHeader.Column title="Host" columnSpan="2 / 4">
+        <CopiableText textToCopy={host} caption={hostCaption} />
       </PageHeader.Column>
     </PageHeader>
   );

--- a/shared/components/CopiableText/CopiableText.js
+++ b/shared/components/CopiableText/CopiableText.js
@@ -1,19 +1,25 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import './CopiableText.scss';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { Button } from 'fundamental-react';
 import copyToCliboard from 'copy-to-clipboard';
 
-export function CopiableText({ text }) {
+CopiableText.propTypes = {
+  textToCopy: PropTypes.string.isRequired,
+  caption: PropTypes.node,
+};
+
+export function CopiableText({ textToCopy, caption }) {
   return (
     <div className="copiable-text">
-      {text}
+      {caption || textToCopy}
       <Tooltip title="Copy to clipboard" position="top">
         <Button
           option="light"
           compact
           glyph="copy"
-          onClick={() => copyToCliboard(text)}
+          onClick={() => copyToCliboard(textToCopy)}
         />
       </Tooltip>
     </div>

--- a/shared/components/CopiableText/test/CopiableText.test.js
+++ b/shared/components/CopiableText/test/CopiableText.test.js
@@ -8,14 +8,24 @@ import copyToClipboard from 'copy-to-clipboard';
 describe('CopiableText', () => {
   it('renders the text', () => {
     const text = 'abcd und 123456';
-    const { queryByText } = render(<CopiableText text={text} />);
+    const { queryByText } = render(<CopiableText textToCopy={text} />);
 
     expect(queryByText(text)).toBeInTheDocument();
   });
 
+  it('renders custom caption', () => {
+    const text = 'abcd und 123456';
+    const caption = <p>Copiable</p>;
+    const { queryByText } = render(
+      <CopiableText textToCopy={text} caption={caption} />,
+    );
+
+    expect(queryByText('Copiable')).toBeInTheDocument();
+  });
+
   it('copies text to clipboard whe button is clicked', () => {
     const text = 'abcd und 123456';
-    const { getByRole } = render(<CopiableText text={text} />);
+    const { getByRole } = render(<CopiableText textToCopy={text} />);
 
     getByRole('button').click();
 

--- a/shared/components/PageHeader/PageHeader.js
+++ b/shared/components/PageHeader/PageHeader.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Panel, Breadcrumb, PanelGrid } from 'fundamental-react';
+import { Panel, Breadcrumb } from 'fundamental-react';
 import './PageHeader.scss';
 import LuigiClient from '@kyma-project/luigi-client';
 
-const Column = ({ title, children }) => (
-  <div className="page-header__column ">
+const Column = ({ title, children, columnSpan = 1 }) => (
+  <div className="page-header__column" style={{ gridColumn: columnSpan }}>
     <p className="title fd-has-type-0 fd-has-color-text-4 fd-has-margin-bottom-none">
       {title}
     </p>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Improve api rule details header
- Add customizable caption to `CopiableText`.
- Add customizable column width to `PageHeader`.

**Related issues**
[Kyma](https://github.com/kyma-project/kyma/pull/6780)