### PR TITLE
Unify backend and frontend naming in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Console is a web-based UI for managing resources within Kyma. It consists of separate front-end applications. Each project is responsible for providing a user interface for particular resource management.
+Console is a web-based UI for managing resources within Kyma. It consists of separate frontend applications. Each project is responsible for providing a user interface for particular resource management.
 
 ### Components
 

--- a/components/angular/generic-list/README.md
+++ b/components/angular/generic-list/README.md
@@ -1,6 +1,6 @@
 # Generic List Components
 
-This is a private package, not published to npm anymore. We use symlinks to use it in our Angular microfrontends.
+This is a private package, not published to npm anymore. We use symlinks to use it in our Angular micro frontends.
 
 ## Development server
 
@@ -11,15 +11,15 @@ A sandbox application appears. It uses `<y-generic-table>` and `<y-generic-list>
 
 To use the package in a component, perform the following steps:
 
-1. Run 
+1. Run
     ```bash
     npm install --save fiori-fundamentals fundamental-ngx
     ```
    in your project directory.
 
-2. Add `"preserveSymlinks": true` to `angular.json` test and build options. Alternatively, add `--preserve-symlink` option to `ng test` and `ng build`. 
+2. Add `"preserveSymlinks": true` to `angular.json` test and build options. Alternatively, add `--preserve-symlink` option to `ng test` and `ng build`.
 
-3. Include 
+3. Include
     ```
     "./node_modules/fiori-fundamentals/dist/fiori-fundamentals.css"
     ```
@@ -27,7 +27,7 @@ To use the package in a component, perform the following steps:
 
 4. Add `"include": [ /components/angular/generic-list/src/app/modules/list/**/*.ts" ]` to  the `tsconfig.json` file of your component.
 
-5. Add `"app"` to  the `tslint.json` file if it includes the following rules: 
+5. Add `"app"` to  the `tslint.json` file if it includes the following rules:
 
     ````
     "no-submodule-imports": [true, "app"],
@@ -42,6 +42,3 @@ For example, the console core has the following symlink set:
     ```
 
 7. Use the generic list in `import * as GenericList from 'app/generic-list'` command.
-    
-
-

--- a/service-catalog-ui/README.md
+++ b/service-catalog-ui/README.md
@@ -6,7 +6,7 @@ The project contains three applications:
 - Service Brokers UI
 - Service Catalog
 - Service Instances
-These applications are included in the Kyma Console as micro front-ends.
+These applications are included in the Kyma Console as micro frontends.
 
 ## Installation
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Unified backend and frontend naming in docs

**Related issue(s)**
See also #https://github.com/kyma-project/kyma/issues/2225
