### PR TITLE
Rename container_name log label after loki migration

### DIFF
--- a/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
+++ b/lambda/src/app/lambdas/lambda-details/lambda-details.component.ts
@@ -1039,7 +1039,7 @@ export class LambdaDetailsComponent implements OnInit, OnDestroy {
         .withParams({
           function: this.lambda.metadata.name,
           namespace: this.namespace,
-          container_name: this.lambda.metadata.name,
+          container: this.lambda.metadata.name,
           compact: 'true',
         })
         .openAsSplitView('/home/cmf-logs',{title: 'Logs', size: 40, collapsed: true});

--- a/logging/src/components/Logs/Logs.js
+++ b/logging/src/components/Logs/Logs.js
@@ -102,7 +102,7 @@ const Logs = ({ readonlyLabels, isCompact, httpService }) => {
 
       if (!showIstioLogs) {
         streams = [...streams].filter(
-          s => !~s.labels.indexOf('container_name="istio-proxy"'),
+          s => !~s.labels.indexOf('container="istio-proxy"'),
         );
       }
       const logs = streams

--- a/logging/src/constants.js
+++ b/logging/src/constants.js
@@ -19,7 +19,7 @@ export const DEFAULT_PERIOD = PERIODS[2];
 export const LOG_LABEL_CATEGORIES = [
   'namespace',
   'function',
-  'container_name',
+  'container',
   'app',
   'chart',
   'job',


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Rename log label `container_name` to `container` after changes in the logging backend service

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/7111