### PR TITLE
Unify compass API URL config key across core and compass charts

### DIFF
--- a/compass/Dockerfile
+++ b/compass/Dockerfile
@@ -40,6 +40,6 @@ COPY --from=ui-generator /app/compass/build var/public
 COPY --from=ui-generator /app/compass/public-luigi var/public-luigi
 COPY --from=ui-generator /app/licenses/ /app/licenses/
 
-EXPOSE 80 8888
+EXPOSE 81 8888
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/compass/nginx.conf
+++ b/compass/nginx.conf
@@ -48,7 +48,7 @@ http {
 
   server {
     server_name localhost2;
-    listen 80 http2;
+    listen 81 http2;
     root /var/public-luigi;
     port_in_redirect off;
 

--- a/compass/public-luigi/config/config.js
+++ b/compass/public-luigi/config/config.js
@@ -1,4 +1,4 @@
 window.clusterConfig = {
   microfrontendContentUrl: 'http://localhost:8888',
-  graphqlApiUrl: 'https://compass-gateway.kyma.local/director/graphql',
+  compassApiUrl: 'https://compass-gateway.kyma.local/director/graphql',
 };

--- a/compass/public/config/config.js
+++ b/compass/public/config/config.js
@@ -1,3 +1,3 @@
 window.clusterConfig = {
-  graphqlApiUrl: 'https://compass-gateway.kyma.local/director/graphql',
+  compassApiUrl: 'https://compass-gateway.kyma.local/director/graphql',
 };

--- a/compass/src/config/luigi-config/helpers/navigation-helpers.js
+++ b/compass/src/config/luigi-config/helpers/navigation-helpers.js
@@ -56,7 +56,7 @@ export const getTenantsFromCache = () =>
   JSON.parse(sessionStorage.getItem('tenants')) || [];
 
 const fetchFromGraphql = async data => {
-  const url = window.clusterConfig.graphqlApiUrl;
+  const url = window.clusterConfig.compassApiUrl;
   const response = await fetch(url, {
     method: 'POST',
     cache: 'no-cache',

--- a/compass/src/store/index.js
+++ b/compass/src/store/index.js
@@ -9,7 +9,7 @@ import { onError } from 'apollo-link-error';
 import resolvers from './resolvers';
 import defaults from './defaults';
 
-const COMPASS_GRAPHQL_ENDPOINT = window.clusterConfig.graphqlApiUrl;
+const COMPASS_GRAPHQL_ENDPOINT = window.clusterConfig.compassApiUrl;
 
 function handleUnauthorized() {
   window.parent.postMessage('unauthorized', '*');


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- change compass url config key to use the same key across kyma charts (core & compass)

**Related issue(s)**
https://app.zenhub.com/workspace/o/kyma-project/kyma/issues/7210
