### PR TITLE
Remove the policies that relax the default CSP around js eval

### DIFF
--- a/core/nginx/nginx.conf
+++ b/core/nginx/nginx.conf
@@ -52,7 +52,7 @@ http {
 
             add_header 'Cache-Control' 'public, max-age=300';
             add_header X-Frame-Options 'SAMEORIGIN';
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors 'self'; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors 'self'; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
             add_header X-Content-Type-Options 'nosniff';
         }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove `unsafe-eval` and `unsafe-inline` CSPs to for extra XSS protection

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
