### PR TITLE
Api package on service details and modal

### DIFF
--- a/service-catalog-ui/catalog/src/components/App/App.js
+++ b/service-catalog-ui/catalog/src/components/App/App.js
@@ -11,7 +11,7 @@ import { backendModuleExists } from '../../commons/helpers';
 Modal.MODAL_APP_REF = '#root';
 
 const ServiceDetails = ({ match }) => (
-  <ServiceClassDetails name={match.params.name} />
+  <ServiceClassDetails name={match.params.name} plan={match.params.plan} />
 );
 
 export default function App() {
@@ -23,6 +23,11 @@ export default function App() {
             <Switch>
               <Route exact path="/" component={ServiceClassList} />
               <Route exact path="/details/:name" component={ServiceDetails} />
+              <Route
+                exact
+                path="/details/:name/plan/:plan"
+                component={ServiceDetails}
+              />
             </Switch>
           </BrowserRouter>
         </NotificationProvider>

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.component.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.component.js
@@ -93,7 +93,7 @@ const PlanColumnContent = ({
 };
 
 PlanColumnContent.proTypes = {
-  preselectedPlan: SERVICE_PLAN_SHAPE.isRequired,
+  preselectedPlan: SERVICE_PLAN_SHAPE,
   defaultPlan: SERVICE_PLAN_SHAPE,
   onPlanChange: PropTypes.func.isRequired,
   dropdownRef: CustomPropTypes.ref.isRequired,

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.component.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.component.js
@@ -13,6 +13,13 @@ import {
   randomNameGenerator,
 } from '../../../commons/helpers';
 
+import { CustomPropTypes } from '../../../react-shared';
+
+const SERVICE_PLAN_SHAPE = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  displayName: PropTypes.string.isRequired,
+});
+
 CreateInstanceModal.propTypes = {
   onChange: PropTypes.func.isRequired,
   onCompleted: PropTypes.func.isRequired,
@@ -22,6 +29,7 @@ CreateInstanceModal.propTypes = {
   item: PropTypes.object,
 
   checkInstanceExistQuery: PropTypes.object.isRequired,
+  preselectedPlan: SERVICE_PLAN_SHAPE,
 };
 
 const parseDefaultIntegerValues = plan => {
@@ -44,6 +52,53 @@ const getInstanceCreateParameterSchema = (plans, currentPlan) => {
 
   return (schema && schema.instanceCreateParameterSchema) || {};
 };
+
+const PlanColumnContent = ({
+  preselectedPlan,
+  defaultPlan,
+  onPlanChange,
+  dropdownRef,
+  allPlans,
+}) => {
+  if (preselectedPlan)
+    return (
+      <>
+        <FormLabel htmlFor="plan">Plan (preselected)</FormLabel>
+        <p className="fd-has-font-weight-light">
+          {preselectedPlan.displayName}
+        </p>
+      </>
+    );
+  else
+    return (
+      <>
+        <FormLabel required htmlFor="plan">
+          Plan
+        </FormLabel>
+        <select
+          id="plan"
+          ref={dropdownRef}
+          defaultValue={defaultPlan}
+          onChange={onPlanChange}
+        >
+          {allPlans.map((p, i) => (
+            <option key={['plan', i].join('_')} value={p.name}>
+              {getResourceDisplayName(p)}
+            </option>
+          ))}
+        </select>
+      </>
+    );
+};
+
+PlanColumnContent.proTypes = {
+  preselectedPlan: SERVICE_PLAN_SHAPE.isRequired,
+  defaultPlan: SERVICE_PLAN_SHAPE,
+  onPlanChange: PropTypes.func.isRequired,
+  dropdownRef: CustomPropTypes.ref.isRequired,
+  allPlans: PropTypes.arrayOf(SERVICE_PLAN_SHAPE),
+};
+
 export default function CreateInstanceModal({
   onChange,
   onCompleted,
@@ -52,6 +107,7 @@ export default function CreateInstanceModal({
   jsonSchemaFormRef,
   item,
   checkInstanceExistQuery,
+  preselectedPlan,
 }) {
   const plans = (item && item.plans) || [];
   plans.forEach(plan => {
@@ -59,7 +115,8 @@ export default function CreateInstanceModal({
   });
   const defaultName =
     `${item.externalName}-${randomNameGenerator()}` || randomNameGenerator();
-  const plan = plans[0].name;
+  const plan = preselectedPlan ? preselectedPlan.name : plans[0].name;
+
   const [instanceCreateParameters, setInstanceCreateParameters] = useState({});
   const [
     instanceCreateParameterSchema,
@@ -92,7 +149,7 @@ export default function CreateInstanceModal({
     );
     onChange(formEvent);
   };
-  const handleChangePlan = e => {
+  const handlePlanChange = e => {
     const newParametersSchema = getInstanceCreateParameterSchema(
       plans,
       e.target.value,
@@ -108,6 +165,7 @@ export default function CreateInstanceModal({
     e.preventDefault();
     try {
       const currentPlan =
+        preselectedPlan ||
         plans.find(e => e.name === formValues.plan.current.value) ||
         (plans.length && plans[0]);
       const labels =
@@ -169,19 +227,13 @@ export default function CreateInstanceModal({
               />
             </div>
             <div className="column">
-              <FormLabel htmlFor="plan">Plan*</FormLabel>
-              <select
-                id="plan"
-                ref={formValues.plan}
-                defaultValue={plans[0]}
-                onChange={handleChangePlan}
-              >
-                {plans.map((p, i) => (
-                  <option key={['plan', i].join('_')} value={p.name}>
-                    {getResourceDisplayName(p)}
-                  </option>
-                ))}
-              </select>
+              <PlanColumnContent
+                preselectedPlan={preselectedPlan}
+                defaultPlan={plan}
+                onPlanChange={handlePlanChange}
+                dropdownRef={formValues.plan}
+                allPlans={plans}
+              />
             </div>
           </div>
         </FormItem>

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.component.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/CreateInstanceModal/CreateInstanceModal.component.js
@@ -77,6 +77,7 @@ const PlanColumnContent = ({
         </FormLabel>
         <select
           id="plan"
+          aria-label="plan-selector"
           ref={dropdownRef}
           defaultValue={defaultPlan}
           onChange={onPlanChange}

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/CreateInstanceModal/test/CreateInstanceModal.test.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/CreateInstanceModal/test/CreateInstanceModal.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { MockedProvider } from '@apollo/react-testing';
+import { render } from '@testing-library/react';
 import { componentUpdate } from '../../../../testing';
 import {
   clusterServiceClassDetails,
@@ -272,5 +273,52 @@ describe('CreateInstanceModal', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       `cmf-instances/details/${clusterServiceClass1Name}`,
     );
+  });
+
+  describe('Preselected plan', () => {
+    let gqlMock;
+    const testPlan = {
+      name: 'testname',
+      displayName: "Look, it's a bird!",
+    };
+    beforeEach(() => {
+      gqlMock = createServiceInstanceErrorMock();
+    });
+
+    it('Shows the preselected plan name', () => {
+      const { queryByText } = render(
+        <MockedProvider mocks={[gqlMock]} addTypename={false}>
+          <CreateInstanceModal
+            checkInstanceExistQuery={{ serviceInstances: [] }}
+            item={clusterServiceClassDetails}
+            formElementRef={{ current: null }}
+            jsonSchemaFormRef={{ current: null }}
+            onChange={onChange}
+            onError={onError}
+            onCompleted={onCompleted}
+            preselectedPlan={testPlan}
+          />
+        </MockedProvider>,
+      );
+      expect(queryByText(testPlan.displayName)).toBeInTheDocument();
+    });
+
+    it("Doesn't render the plan selection", () => {
+      const { queryByLabelText } = render(
+        <MockedProvider mocks={[gqlMock]} addTypename={false}>
+          <CreateInstanceModal
+            checkInstanceExistQuery={{ serviceInstances: [] }}
+            item={clusterServiceClassDetails}
+            formElementRef={{ current: null }}
+            jsonSchemaFormRef={{ current: null }}
+            onChange={onChange}
+            onError={onError}
+            onCompleted={onCompleted}
+            preselectedPlan={testPlan}
+          />
+        </MockedProvider>,
+      );
+      expect(queryByLabelText('plan-selector')).not.toBeInTheDocument();
+    });
   });
 });

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
@@ -12,7 +12,7 @@ import {
 
 import ServiceClassTabs from './ServiceClassTabs/ServiceClassTabs';
 import CreateInstanceModal from './CreateInstanceModal/CreateInstanceModal.container';
-
+import { Identifier } from 'fundamental-react';
 import ModalWithForm from '../../shared/ModalWithForm/ModalWithForm';
 import { isStringValueEqualToTrue } from '../../commons/helpers';
 import './ServiceClassDetails.scss';
@@ -24,9 +24,14 @@ import {
   backendModuleExists,
 } from '../../commons/helpers';
 import ServiceClassDetailsHeader from './ServiceClassDetailsHeader/ServiceClassDetailsHeader.component';
+import {
+  DOCUMENTATION_PER_PLAN_LABEL,
+  DOCUMENTATION_PER_PLAN_DESCRIPTION,
+} from '../../shared/constants';
 
-export default function ServiceClassDetails({ name }) {
+export default function ServiceClassDetails({ name, plan }) {
   const namespace = LuigiClient.getEventData().environmentId;
+
   const {
     data: queryData,
     loading: queryLoading,
@@ -59,6 +64,7 @@ export default function ServiceClassDetails({ name }) {
   if (!serviceClass) {
     return <EmptyList>{serviceClassConstants.noClassText}</EmptyList>;
   }
+  // console.log(serviceClass);
 
   const serviceClassDisplayName = getResourceDisplayName(serviceClass);
 
@@ -83,7 +89,17 @@ export default function ServiceClassDetails({ name }) {
     imageUrl,
     tags,
     labels,
+    plans,
   } = serviceClass;
+
+  const isAPIpackage = labels[DOCUMENTATION_PER_PLAN_LABEL] === 'true';
+  const currentPlan = isAPIpackage
+    ? plans.find(p => p.name === plan)
+    : undefined;
+  console.log(currentPlan);
+  if (isAPIpackage && !currentPlan) {
+    //TODO: error - no plan provided
+  }
 
   return (
     <>
@@ -98,7 +114,9 @@ export default function ServiceClassDetails({ name }) {
         labels={labels}
         description={serviceClassDescription}
         isProvisionedOnlyOnce={isProvisionedOnlyOnce}
+        isAPIpackage={isAPIpackage}
       >
+        <Identifier glyph="washing-machine" size="s" />
         <ModalWithForm
           title={`Provision the ${serviceClass.displayName}${' '}
                     ${

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
@@ -28,6 +28,7 @@ import {
   DOCUMENTATION_PER_PLAN_LABEL,
   DOCUMENTATION_PER_PLAN_DESCRIPTION,
 } from '../../shared/constants';
+import { Tooltip } from '../../react-shared';
 
 export default function ServiceClassDetails({ name, plan }) {
   const namespace = LuigiClient.getEventData().environmentId;
@@ -64,7 +65,6 @@ export default function ServiceClassDetails({ name, plan }) {
   if (!serviceClass) {
     return <EmptyList>{serviceClassConstants.noClassText}</EmptyList>;
   }
-  // console.log(serviceClass);
 
   const serviceClassDisplayName = getResourceDisplayName(serviceClass);
 
@@ -116,7 +116,12 @@ export default function ServiceClassDetails({ name, plan }) {
         isProvisionedOnlyOnce={isProvisionedOnlyOnce}
         isAPIpackage={isAPIpackage}
       >
-        <Identifier glyph="washing-machine" size="s" />
+        {isAPIpackage && (
+          <Tooltip title={DOCUMENTATION_PER_PLAN_DESCRIPTION}>
+            <Identifier id="docs-per-plan-icon" glyph="sap-box" size="s" />
+          </Tooltip>
+        )}
+
         <ModalWithForm
           title={`Provision the ${serviceClass.displayName}${' '}
                     ${

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
@@ -11,7 +11,7 @@ import {
 
 import ServiceClassTabs from './ServiceClassTabs/ServiceClassTabs';
 import CreateInstanceModal from './CreateInstanceModal/CreateInstanceModal.container';
-import { Identifier } from 'fundamental-react';
+import { Identifier, Button } from 'fundamental-react';
 import ModalWithForm from '../../shared/ModalWithForm/ModalWithForm';
 import { isStringValueEqualToTrue } from '../../commons/helpers';
 import './ServiceClassDetails.scss';
@@ -28,7 +28,6 @@ import {
   DOCUMENTATION_PER_PLAN_DESCRIPTION,
 } from '../../shared/constants';
 import { Tooltip, Spinner } from '../../react-shared';
-import { Button } from 'fundamental-react';
 
 export default function ServiceClassDetails({ name, plan }) {
   const namespace = LuigiClient.getEventData().environmentId;

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { useQuery } from '@apollo/react-hooks';
 import { getServiceClass } from './queries';
-import { Spinner } from '@kyma-project/react-components';
 
 import {
   serviceClassConstants,
@@ -28,7 +27,8 @@ import {
   DOCUMENTATION_PER_PLAN_LABEL,
   DOCUMENTATION_PER_PLAN_DESCRIPTION,
 } from '../../shared/constants';
-import { Tooltip } from '../../react-shared';
+import { Tooltip, Spinner } from '../../react-shared';
+import { Button } from 'fundamental-react';
 
 export default function ServiceClassDetails({ name, plan }) {
   const namespace = LuigiClient.getEventData().environmentId;
@@ -96,9 +96,29 @@ export default function ServiceClassDetails({ name, plan }) {
   const currentPlan = isAPIpackage
     ? plans.find(p => p.name === plan)
     : undefined;
-  console.log(currentPlan);
+
   if (isAPIpackage && !currentPlan) {
-    //TODO: error - no plan provided
+    //TODO: redrection to the plan selection view?
+    LuigiClient.uxManager().showAlert({
+      type: 'error',
+      text:
+        'The provided plan name is wrong. Please make sure you selected the right one.',
+    });
+
+    return (
+      <section className="fd-section">
+        <Button
+          glyph="nav-back"
+          onClick={() =>
+            LuigiClient.linkManager()
+              .fromClosestContext()
+              .navigate('/')
+          }
+        >
+          Go back to the Catalog
+        </Button>
+      </section>
+    );
   }
 
   return (

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
@@ -114,7 +114,6 @@ export default function ServiceClassDetails({ name, plan }) {
         labels={labels}
         description={serviceClassDescription}
         isProvisionedOnlyOnce={isProvisionedOnlyOnce}
-        isAPIpackage={isAPIpackage}
       >
         {isAPIpackage && (
           <Tooltip title={DOCUMENTATION_PER_PLAN_DESCRIPTION}>
@@ -137,7 +136,9 @@ export default function ServiceClassDetails({ name, plan }) {
           }}
           id="add-instance-modal"
           item={serviceClass}
-          renderForm={props => <CreateInstanceModal {...props} />}
+          renderForm={props => (
+            <CreateInstanceModal {...props} preselectedPlan={currentPlan} />
+          )}
         />
       </ServiceClassDetailsHeader>
 

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.js
@@ -137,7 +137,12 @@ export default function ServiceClassDetails({ name, plan }) {
       >
         {isAPIpackage && (
           <Tooltip title={DOCUMENTATION_PER_PLAN_DESCRIPTION}>
-            <Identifier id="docs-per-plan-icon" glyph="sap-box" size="s" />
+            <Identifier
+              id="docs-per-plan-icon"
+              glyph="sap-box"
+              label="docs-per-plan-icon"
+              size="s"
+            />
           </Tooltip>
         )}
 

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.scss
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetails.scss
@@ -1,9 +1,14 @@
 #add-instance-modal {
-    .fd-modal {
-      max-width: 90%;
-    }
-    .fd-modal__content {
-      width: 49em;
-      min-width: 680px;
-    }
+  .fd-modal {
+    max-width: 90%;
   }
+  .fd-modal__content {
+    width: 49em;
+    min-width: 680px;
+  }
+}
+
+#docs-per-plan-icon {
+  cursor: help;
+  margin-bottom: 2px;
+}

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetailsHeader/ServiceClassDetailsHeader.component.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/ServiceClassDetailsHeader/ServiceClassDetailsHeader.component.js
@@ -78,7 +78,7 @@ ServiceClassDetailsHeader.propTypes = {
   description: PropTypes.string,
   serviceClassDisplayName: PropTypes.string.isRequired,
   providerDisplayName: PropTypes.string,
-  children: PropTypes.element,
+  children: PropTypes.node,
   labels: PropTypes.object,
   tags: PropTypes.array,
   documentationUrl: PropTypes.string,

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/test/ServiceClassDetails.test.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/test/ServiceClassDetails.test.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import { mount } from 'enzyme';
+import { render, wait } from '@testing-library/react';
 import {
   serviceClassQuery,
+  serviceClassAPIruleQuery,
   mockEnvironmentId,
 } from '../../../testing/queriesMocks';
-import { clusterServiceClass1Name } from '../../../testing/serviceClassesMocks';
+import {
+  clusterServiceClass1Name,
+  serviceClassWithAPIrule,
+} from '../../../testing/serviceClassesMocks';
 import ServiceClassDetails from '../ServiceClassDetails';
 import { Spinner } from '../../../react-shared';
 import { componentUpdate } from '../../../testing';
@@ -14,6 +19,7 @@ import ServiceClassDetailsHeader from '../ServiceClassDetailsHeader/ServiceClass
 const mockNavigate = jest.fn();
 const mockAddBackdrop = jest.fn();
 const mockRemoveBackdrop = jest.fn();
+const mockShowAlert = jest.fn();
 
 jest.mock('@kyma-project/generic-documentation', () => {
   return <div>GENERIC DOCUMENTATION COMPONENT</div>;
@@ -34,6 +40,7 @@ jest.mock('@kyma-project/luigi-client', () => ({
   uxManager: () => ({
     addBackdrop: mockAddBackdrop,
     removeBackdrop: mockRemoveBackdrop,
+    showAlert: mockShowAlert,
   }),
 }));
 
@@ -54,6 +61,7 @@ describe('Service Class Details UI', () => {
 
     await componentUpdate(component);
     expect(component.find(Spinner).exists()).toBe(false);
+    await componentUpdate(component); // get rid of 'act' warning that pops up randmly
   });
 
   it('Displays service class details ', async () => {
@@ -66,5 +74,55 @@ describe('Service Class Details UI', () => {
     await componentUpdate(component);
 
     expect(component.find(ServiceClassDetailsHeader).exists()).toBe(true);
+    await componentUpdate(component); // get rid of 'act' warning that pops up randmly
+  });
+
+  describe('API packages', () => {
+    it('Shows error when the provided plan name is wrong', async () => {
+      render(
+        <MockedProvider mocks={[serviceClassAPIruleQuery]}>
+          <ServiceClassDetails
+            plan="non-existing"
+            name={serviceClassWithAPIrule.name}
+          />
+        </MockedProvider>,
+      );
+
+      await wait(() => {
+        expect(mockShowAlert).toHaveBeenCalledWith({
+          type: 'error',
+          text:
+            'The provided plan name is wrong. Please make sure you selected the right one.',
+        });
+        mockShowAlert.mockReset();
+      });
+    });
+
+    it('Shows API package icon when the label is present', async () => {
+      const { queryByLabelText } = render(
+        <MockedProvider mocks={[serviceClassAPIruleQuery]}>
+          <ServiceClassDetails
+            plan={serviceClassWithAPIrule.plans[0].name}
+            name={serviceClassWithAPIrule.name}
+          />
+        </MockedProvider>,
+      );
+
+      await wait(() => {
+        expect(queryByLabelText('docs-per-plan-icon')).toBeInTheDocument();
+      });
+    });
+
+    it("Doesn't show API package icon when label isn't present", async () => {
+      const { queryByLabelText } = render(
+        <MockedProvider mocks={[serviceClassQuery]}>
+          <ServiceClassDetails name={serviceClassWithAPIrule.name} />
+        </MockedProvider>,
+      );
+
+      await wait(() => {
+        expect(queryByLabelText('docs-per-plan-icon')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/service-catalog-ui/catalog/src/components/ServiceClassDetails/test/ServiceClassDetails.test.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassDetails/test/ServiceClassDetails.test.js
@@ -7,7 +7,7 @@ import {
 } from '../../../testing/queriesMocks';
 import { clusterServiceClass1Name } from '../../../testing/serviceClassesMocks';
 import ServiceClassDetails from '../ServiceClassDetails';
-import { Spinner } from '@kyma-project/react-components';
+import { Spinner } from '../../../react-shared';
 import { componentUpdate } from '../../../testing';
 import ServiceClassDetailsHeader from '../ServiceClassDetailsHeader/ServiceClassDetailsHeader.component';
 

--- a/service-catalog-ui/catalog/src/components/ServiceClassList/Cards/Card.component.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassList/Cards/Card.component.js
@@ -16,9 +16,10 @@ import {
   CardImage,
   CardDescription,
 } from './styled';
-
-const DOCUMENTATION_PER_PLAN_DESCRIPTION = `Every plan comes with a separate API and matching documentation`;
-const DOCUMENTATION_PER_PLAN_LABEL = 'documentation-per-plan';
+import {
+  DOCUMENTATION_PER_PLAN_LABEL,
+  DOCUMENTATION_PER_PLAN_DESCRIPTION,
+} from '../../../shared/constants';
 
 const Card = ({
   title,

--- a/service-catalog-ui/catalog/src/shared/constants.js
+++ b/service-catalog-ui/catalog/src/shared/constants.js
@@ -1,0 +1,2 @@
+export const DOCUMENTATION_PER_PLAN_DESCRIPTION = `Every plan comes with a separate API and matching documentation`;
+export const DOCUMENTATION_PER_PLAN_LABEL = 'documentation-per-plan';

--- a/service-catalog-ui/catalog/src/testing/queriesMocks.js
+++ b/service-catalog-ui/catalog/src/testing/queriesMocks.js
@@ -9,6 +9,7 @@ import {
   clusterServiceClassDetails,
   clusterServiceClass3,
   serviceClass2,
+  serviceClassWithAPIrule,
 } from './serviceClassesMocks';
 
 import { filterExtensions } from '../variables';
@@ -71,6 +72,23 @@ export const serviceClassQuery = {
     data: {
       clusterServiceClass: clusterServiceClassDetails,
       serviceClass: null,
+    },
+  },
+};
+
+export const serviceClassAPIruleQuery = {
+  request: {
+    query: getServiceClass,
+    variables: {
+      namespace: mockEnvironmentId,
+      name: serviceClassWithAPIrule.name,
+      fileExtensions: filterExtensions,
+    },
+  },
+  result: {
+    data: {
+      clusterServiceClass: null,
+      serviceClass: serviceClassWithAPIrule,
     },
   },
 };

--- a/service-catalog-ui/catalog/src/testing/serviceClassesMocks.js
+++ b/service-catalog-ui/catalog/src/testing/serviceClassesMocks.js
@@ -1,3 +1,4 @@
+import { DOCUMENTATION_PER_PLAN_LABEL } from '../shared/constants';
 const clusterServiceClass1Name = 'testName';
 
 const clusterServiceClass1 = {
@@ -67,6 +68,33 @@ const serviceClass2 = {
   name: '4124',
   providerDisplayName: 'HakunaMatataprovider2',
   tags: [],
+  __typename: 'ServiceClass',
+};
+
+const serviceClassWithAPIrule = {
+  activated: false,
+  description: 'Description 2',
+  displayName: 'serviceClass displayName2',
+  externalName: 'service-class-name-1',
+  imageUrl: '',
+  instances: [],
+  labels: {
+    provisionOnlyOnce: 'true',
+    [DOCUMENTATION_PER_PLAN_LABEL]: 'true',
+    someLabel: 'somevalue',
+  },
+  name: 'service-with-api-rule',
+  providerDisplayName: 'HakunaMatataprovider2',
+  tags: [],
+  plans: [
+    {
+      displayName: 'Plan1',
+      externalName: 'plan1',
+      name: 'test-plan',
+      __typename: 'ServicePlan',
+    },
+  ],
+  creationTimestamp: 1572525371,
   __typename: 'ServiceClass',
 };
 
@@ -218,4 +246,5 @@ export {
   clusterServiceClass1Name,
   clusterServiceClassDetails,
   clusterServiceClassDetailsNoPlanSpec,
+  serviceClassWithAPIrule,
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

I recommend to test it on `api-packages-mock` cluster 👌 

**Description**

Changes proposed in this pull request:

- Support preselected plan in CreateInstanceModal (no dropdown and pass the plan name further)
- Show error if a service has _documentation-per-plan_ label but no valid plan is provided
- Show icon with a tooltip if a service has the label
- hide the label on the label list

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
