### PR TITLE
Default auth in core-ui API Packages

### DIFF
--- a/core-ui/src/apollo.js
+++ b/core-ui/src/apollo.js
@@ -1,5 +1,8 @@
 import { ApolloClient } from 'apollo-client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import {
+  InMemoryCache,
+  IntrospectionFragmentMatcher,
+} from 'apollo-cache-inmemory';
 import { HttpLink } from 'apollo-link-http';
 import { onError } from 'apollo-link-error';
 import { ApolloLink } from 'apollo-link';
@@ -26,6 +29,14 @@ const errorLink = onError(
 );
 
 export function createCompassApolloClient() {
+  const fragmentMatcher = new IntrospectionFragmentMatcher({
+    introspectionQueryResultData: {
+      __schema: {
+        types: [],
+      },
+    },
+  });
+
   const graphqlApiUrl = getURL('compassApiUrl');
 
   //TODO: should be removed once management plane API is able to resolve tenant from token
@@ -42,6 +53,7 @@ export function createCompassApolloClient() {
   return new ApolloClient({
     link: ApolloLink.from([errorLink, httpLink]),
     cache: new InMemoryCache({
+      fragmentMatcher,
       dataIdFromObject: object => object.name || null,
     }),
   });

--- a/core-ui/src/components/ApiPackages/ApiPackageDetails/ApiPackageDetails.js
+++ b/core-ui/src/components/ApiPackages/ApiPackageDetails/ApiPackageDetails.js
@@ -6,6 +6,7 @@ import EventList from './EventList/EventList';
 import AuthList from './AuthList/AuthList';
 
 import { ResourceNotFound } from 'react-shared';
+import { TabGroup, Tab } from 'fundamental-react';
 
 import { useQuery } from '@apollo/react-hooks';
 import { GET_API_PACKAGE } from 'gql/queries';
@@ -48,17 +49,23 @@ export default function ApiPackageDetails({ applicationId, apiPackageId }) {
   return (
     <>
       <Header apiPackage={apiPackage} application={application} />
-      <AuthList auths={apiPackage.instanceAuths} />
-      <ApiList
-        apiDefinitions={apiPackage.apiDefinitions.data}
-        applicationId={application.id}
-        apiPackageId={apiPackage.id}
-      />
-      <EventList
-        eventDefinitions={apiPackage.eventDefinitions.data}
-        applicationId={application.id}
-        apiPackageId={apiPackage.id}
-      />
+      <TabGroup>
+        <Tab key="api-list" id="api-list" title="API Package Content">
+          <ApiList
+            apiDefinitions={apiPackage.apiDefinitions.data}
+            applicationId={application.id}
+            apiPackageId={apiPackage.id}
+          />
+          <EventList
+            eventDefinitions={apiPackage.eventDefinitions.data}
+            applicationId={application.id}
+            apiPackageId={apiPackage.id}
+          />
+        </Tab>
+        <Tab key="auth-data" id="auth-data" title="Auth data">
+          <AuthList auths={apiPackage.instanceAuths} />
+        </Tab>
+      </TabGroup>
     </>
   );
 }

--- a/core-ui/src/components/ApiPackages/ApiPackageDetails/EditApiPackageForm/EditApiPackageForm.js
+++ b/core-ui/src/components/ApiPackages/ApiPackageDetails/EditApiPackageForm/EditApiPackageForm.js
@@ -36,15 +36,12 @@ export default function EditApiPackageForm({
   const compassGqlClient = React.useContext(CompassGqlContext);
   const [updateApiPackage] = useMutation(UPDATE_API_PACKAGE, {
     client: compassGqlClient,
-    refetchQueries: () => {
-      console.log('refetch');
-      return [
-        {
-          query: GET_API_PACKAGE,
-          variables: { applicationId, apiPackageId: apiPackage.id },
-        },
-      ];
-    },
+    refetchQueries: () => [
+      {
+        query: GET_API_PACKAGE,
+        variables: { applicationId, apiPackageId: apiPackage.id },
+      },
+    ],
   });
 
   const name = React.useRef();

--- a/core-ui/src/components/ApiPackages/ApiPackageDetails/EditApiPackageForm/EditApiPackageForm.js
+++ b/core-ui/src/components/ApiPackages/ApiPackageDetails/EditApiPackageForm/EditApiPackageForm.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CustomPropTypes } from 'react-shared';
 
-import { FormLabel, FormItem } from 'fundamental-react';
-import { JSONEditor } from 'react-shared';
+import { FormLabel, FormItem, Tab, TabGroup, FormSet } from 'fundamental-react';
+import { JSONEditor, CustomPropTypes, CredentialsForm } from 'react-shared';
+import {
+  inferCredentialType,
+  inferDefaultCredentials,
+  getCredentialsRefsValue,
+} from '../../ApiPackageHelpers';
 
 import { useMutation } from '@apollo/react-hooks';
-import { UPDATE_API_PACKAGE, GET_API_PACKAGE } from './../../gql';
+import { GET_API_PACKAGE } from 'gql/queries';
+import { UPDATE_API_PACKAGE } from 'gql/mutations';
 import { CompassGqlContext } from 'index';
 
 EditApiPackageForm.propTypes = {
@@ -31,18 +36,43 @@ export default function EditApiPackageForm({
   const compassGqlClient = React.useContext(CompassGqlContext);
   const [updateApiPackage] = useMutation(UPDATE_API_PACKAGE, {
     client: compassGqlClient,
-    refetchQueries: () => [
-      {
-        query: GET_API_PACKAGE,
-        variables: { applicationId, apiPackageId: apiPackage.id },
-      },
-    ],
+    refetchQueries: () => {
+      console.log('refetch');
+      return [
+        {
+          query: GET_API_PACKAGE,
+          variables: { applicationId, apiPackageId: apiPackage.id },
+        },
+      ];
+    },
   });
 
   const name = React.useRef();
   const description = React.useRef();
+  const credentialRefs = {
+    oAuth: {
+      clientId: React.useRef(null),
+      clientSecret: React.useRef(null),
+      url: React.useRef(null),
+    },
+    basic: {
+      username: React.useRef(null),
+      password: React.useRef(null),
+    },
+  };
   const [requestInputSchema, setRequestInputSchema] = React.useState(
     JSON.parse(apiPackage.instanceAuthRequestInputSchema || '{}'),
+  );
+
+  const credentials =
+    apiPackage.defaultInstanceAuth && apiPackage.defaultInstanceAuth.credential;
+  const [credentialsType, setCredentialsType] = React.useState(
+    inferCredentialType(credentials),
+  );
+
+  const defaultCredentials = inferDefaultCredentials(
+    credentialsType,
+    credentials,
   );
 
   const handleSchemaChange = schema => {
@@ -56,10 +86,12 @@ export default function EditApiPackageForm({
 
   const handleFormSubmit = async () => {
     const apiName = name.current.value;
+    const credentials = getCredentialsRefsValue(credentialRefs);
     const input = {
       name: apiName,
       description: description.current.value,
       instanceAuthRequestInputSchema: JSON.stringify(requestInputSchema),
+      defaultInstanceAuth: credentials,
     };
     try {
       await updateApiPackage({
@@ -76,39 +108,61 @@ export default function EditApiPackageForm({
   };
 
   return (
-    <form ref={formElementRef} onChange={onChange} onSubmit={handleFormSubmit}>
-      <FormItem key="name">
-        <FormLabel htmlFor="name" required={true}>
-          Name
-        </FormLabel>
-        <input
-          ref={name}
-          required={true}
-          id="name"
-          type="text"
-          placeholder="Name"
-          autoComplete="off"
-          defaultValue={apiPackage.name}
-        />
-      </FormItem>
-
-      <FormItem key="description">
-        <FormLabel htmlFor="description">Description</FormLabel>
-        <input
-          ref={description}
-          id="description"
-          type="text"
-          placeholder="Description"
-          autoComplete="off"
-          defaultValue={apiPackage.description}
-        />
-      </FormItem>
-      <FormLabel>Request input schema</FormLabel>
-      <JSONEditor
-        aria-label="schema-editor"
-        onChangeText={handleSchemaChange}
-        text={JSON.stringify(requestInputSchema, null, 2)}
-      />
+    <form
+      ref={formElementRef}
+      onChange={onChange}
+      onSubmit={handleFormSubmit}
+      style={{ minHeight: '440px' }}
+    >
+      <TabGroup>
+        <Tab key="package-data" id="package-data" title="Data">
+          <FormItem key="name">
+            <FormLabel htmlFor="name" required={true}>
+              Name
+            </FormLabel>
+            <input
+              ref={name}
+              required={true}
+              id="name"
+              type="text"
+              placeholder="Name"
+              autoComplete="off"
+              defaultValue={apiPackage.name}
+            />
+          </FormItem>
+          <FormItem key="description">
+            <FormLabel htmlFor="description">Description</FormLabel>
+            <input
+              ref={description}
+              id="description"
+              type="text"
+              placeholder="Description"
+              autoComplete="off"
+              defaultValue={apiPackage.description}
+            />
+          </FormItem>
+          <FormLabel>Request input schema</FormLabel>
+          <JSONEditor
+            aria-label="schema-editor"
+            onChangeText={handleSchemaChange}
+            text={JSON.stringify(requestInputSchema, null, 2)}
+          />
+        </Tab>
+        <Tab
+          key="package-credentials"
+          id="package-credentials"
+          title="Credentials"
+        >
+          <FormSet>
+            <CredentialsForm
+              credentialRefs={credentialRefs}
+              credentialType={credentialsType}
+              setCredentialType={setCredentialsType}
+              defaultValues={defaultCredentials}
+            />
+          </FormSet>
+        </Tab>
+      </TabGroup>
     </form>
   );
 }

--- a/core-ui/src/components/ApiPackages/ApiPackageDetails/EditApiPackageForm/test/EditApiPackageForm.test.js
+++ b/core-ui/src/components/ApiPackages/ApiPackageDetails/EditApiPackageForm/test/EditApiPackageForm.test.js
@@ -6,6 +6,10 @@ import EditApiPackageForm from '../EditApiPackageForm';
 import {
   apiPackageMock,
   updateApiPackageMock,
+  basicCredentialsMock,
+  updateApiPackageWithBasicMock,
+  oAuthCredentialsMock,
+  updateApiPackageWithOAuthMock,
   refetchApiPackageMock,
 } from './mocks';
 
@@ -26,11 +30,9 @@ jest.mock('react-shared', () => ({
 
 describe('EditApiPackageForm', () => {
   it('Fills the form with API Package data', async () => {
-    console.warn = jest.fn(); // componentWillUpdate on JSONEditorComponent
-
     const formRef = React.createRef();
 
-    const { queryByLabelText } = render(
+    const { queryByLabelText, getByText, queryByText } = render(
       <MockedProvider
         mocks={[updateApiPackageMock, refetchApiPackageMock]}
         addTypename={false}
@@ -54,11 +56,12 @@ describe('EditApiPackageForm', () => {
     const descriptionField = queryByLabelText('Description');
     expect(descriptionField).toBeInTheDocument();
     expect(descriptionField.value).toBe(apiPackageMock.description);
+
+    fireEvent.click(getByText('Credentials'));
+    expect(queryByText('None')).toBeInTheDocument();
   });
 
-  it('Sends request and shows notification on form submit', async () => {
-    console.warn = jest.fn(); // componentWillUpdate on JSONEditorComponent
-
+  it('Sends request and shows notification on form submit with no credentials', async () => {
     const formRef = React.createRef();
     const completedCallback = jest.fn();
 
@@ -84,6 +87,89 @@ describe('EditApiPackageForm', () => {
     });
     fireEvent.change(getByLabelText('Description'), {
       target: { value: 'api-package-description-2' },
+    });
+
+    // simulate form submit from outside
+    formRef.current.dispatchEvent(new Event('submit'));
+
+    await wait(() => expect(completedCallback).toHaveBeenCalled());
+  });
+
+  it('Sends request and shows notification on form submit with Basic credentials', async () => {
+    console.error = jest.fn(); // Warning: `NaN` is an invalid value for the `left` css style property.
+
+    const formRef = React.createRef();
+    const completedCallback = jest.fn();
+
+    const { getByLabelText, getByText } = render(
+      <MockedProvider
+        mocks={[updateApiPackageWithBasicMock, refetchApiPackageMock]}
+        addTypename={false}
+      >
+        <EditApiPackageForm
+          applicationId="app-id"
+          apiPackage={apiPackageMock}
+          formElementRef={formRef}
+          onChange={() => {}}
+          onCompleted={completedCallback}
+          onError={() => {}}
+          setCustomValid={() => {}}
+        />
+      </MockedProvider>,
+    );
+
+    fireEvent.click(getByText('Credentials')); // select tab
+    fireEvent.click(getByText('None')); // open dropdown
+    fireEvent.click(getByText('Basic')); // select basic credentials
+
+    fireEvent.change(getByLabelText(/Username/), {
+      target: { value: basicCredentialsMock.username },
+    });
+    fireEvent.change(getByLabelText(/Password/), {
+      target: { value: basicCredentialsMock.password },
+    });
+
+    // simulate form submit from outside
+    formRef.current.dispatchEvent(new Event('submit'));
+
+    await wait(() => expect(completedCallback).toHaveBeenCalled());
+  });
+
+  it('Sends request and shows notification on form submit with OAuth credentials', async () => {
+    console.error = jest.fn(); // Warning: `NaN` is an invalid value for the `left` css style property.
+
+    const formRef = React.createRef();
+    const completedCallback = jest.fn();
+
+    const { getByLabelText, getByText } = render(
+      <MockedProvider
+        mocks={[updateApiPackageWithOAuthMock, refetchApiPackageMock]}
+        addTypename={false}
+      >
+        <EditApiPackageForm
+          applicationId="app-id"
+          apiPackage={apiPackageMock}
+          formElementRef={formRef}
+          onChange={() => {}}
+          onCompleted={completedCallback}
+          onError={() => {}}
+          setCustomValid={() => {}}
+        />
+      </MockedProvider>,
+    );
+
+    fireEvent.click(getByText('Credentials')); // select tab
+    fireEvent.click(getByText('None')); // open dropdown
+    fireEvent.click(getByText('OAuth')); // select oAuth credentials
+
+    fireEvent.change(getByLabelText(/Client ID/), {
+      target: { value: oAuthCredentialsMock.clientId },
+    });
+    fireEvent.change(getByLabelText(/Client Secret/), {
+      target: { value: oAuthCredentialsMock.clientSecret },
+    });
+    fireEvent.change(getByLabelText(/Url/), {
+      target: { value: oAuthCredentialsMock.url },
     });
 
     // simulate form submit from outside

--- a/core-ui/src/components/ApiPackages/ApiPackageDetails/EditApiPackageForm/test/mocks.js
+++ b/core-ui/src/components/ApiPackages/ApiPackageDetails/EditApiPackageForm/test/mocks.js
@@ -1,10 +1,22 @@
-import { UPDATE_API_PACKAGE, GET_API_PACKAGE } from './../../../gql';
+import { GET_API_PACKAGE } from 'gql/queries';
+import { UPDATE_API_PACKAGE } from 'gql/mutations';
 
 export const apiPackageMock = {
   id: 'package-id',
   name: 'api-package-1',
   description: 'desc',
   instanceAuthRequestInputSchema: '{}',
+};
+
+export const basicCredentialsMock = {
+  username: 'basic-username',
+  password: 'basic-password',
+};
+
+export const oAuthCredentialsMock = {
+  clientId: 'clientId',
+  clientSecret: 'clientSecret',
+  url: 'https://test',
 };
 
 export const updateApiPackageMock = {
@@ -16,6 +28,59 @@ export const updateApiPackageMock = {
         name: 'api-package-name-2',
         description: 'api-package-description-2',
         instanceAuthRequestInputSchema: '{}',
+        defaultInstanceAuth: null,
+      },
+    },
+  },
+  result: {
+    data: {
+      updatePackage: {
+        name: 'package',
+      },
+    },
+  },
+};
+
+export const updateApiPackageWithBasicMock = {
+  request: {
+    query: UPDATE_API_PACKAGE,
+    variables: {
+      id: 'package-id',
+      in: {
+        name: 'api-package-1',
+        description: 'desc',
+        instanceAuthRequestInputSchema: '{}',
+        defaultInstanceAuth: {
+          credential: {
+            basic: basicCredentialsMock,
+          },
+        },
+      },
+    },
+  },
+  result: {
+    data: {
+      updatePackage: {
+        name: 'package',
+      },
+    },
+  },
+};
+
+export const updateApiPackageWithOAuthMock = {
+  request: {
+    query: UPDATE_API_PACKAGE,
+    variables: {
+      id: 'package-id',
+      in: {
+        name: 'api-package-1',
+        description: 'desc',
+        instanceAuthRequestInputSchema: '{}',
+        defaultInstanceAuth: {
+          credential: {
+            oauth: oAuthCredentialsMock,
+          },
+        },
       },
     },
   },
@@ -49,6 +114,7 @@ export const refetchApiPackageMock = {
           instanceAuths: [],
           apiDefinitions: [],
           eventDefinitions: [],
+          defaultInstanceAuth: null,
         },
       },
     },

--- a/core-ui/src/components/ApiPackages/ApiPackageHelpers.js
+++ b/core-ui/src/components/ApiPackages/ApiPackageHelpers.js
@@ -1,0 +1,46 @@
+import {
+  CREDENTIAL_TYPE_NONE,
+  CREDENTIAL_TYPE_OAUTH,
+  CREDENTIAL_TYPE_BASIC,
+  getRefsValues,
+} from 'react-shared';
+
+export const inferCredentialType = credentials => {
+  if (credentials && credentials.__typename) {
+    if (credentials.__typename === 'OAuthCredentialData') {
+      return CREDENTIAL_TYPE_OAUTH;
+    } else if (credentials.__typename === 'BasicCredentialData') {
+      return CREDENTIAL_TYPE_BASIC;
+    }
+  }
+  return CREDENTIAL_TYPE_NONE;
+};
+
+export const inferDefaultCredentials = (credentialsType, credentials) => {
+  if (credentialsType === CREDENTIAL_TYPE_OAUTH) {
+    return {
+      oAuth: {
+        ...credentials,
+      },
+    };
+  } else if (credentialsType === CREDENTIAL_TYPE_BASIC) {
+    return {
+      basic: {
+        ...credentials,
+      },
+    };
+  }
+  return null;
+};
+
+export const getCredentialsRefsValue = credentialRefs => {
+  const oAuthValues = getRefsValues(credentialRefs.oAuth);
+  const basicValues = getRefsValues(credentialRefs.basic);
+  let credentials = null;
+  if (oAuthValues && Object.keys(oAuthValues).length !== 0) {
+    credentials = { credential: { oauth: oAuthValues } };
+  } else if (basicValues && Object.keys(basicValues).length !== 0) {
+    credentials = { credential: { basic: basicValues } };
+  }
+  return credentials;
+};

--- a/core-ui/src/components/ApiPackages/CreateApiPackageForm/CreateApiPackageForm.js
+++ b/core-ui/src/components/ApiPackages/CreateApiPackageForm/CreateApiPackageForm.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CustomPropTypes } from 'react-shared';
+import {
+  CustomPropTypes,
+  CredentialsForm,
+  CREDENTIAL_TYPE_NONE,
+} from 'react-shared';
 
-import { FormLabel, FormItem } from 'fundamental-react';
+import { Tab, TabGroup, FormLabel, FormItem, FormSet } from 'fundamental-react';
 import { JSONEditor } from 'react-shared';
+import { getCredentialsRefsValue } from '../ApiPackageHelpers';
 
 import { useMutation } from '@apollo/react-hooks';
 import { CREATE_API_PACKAGE } from 'gql/mutations';
@@ -37,7 +42,21 @@ export default function CreateApiPackageForm({
 
   const name = React.useRef();
   const description = React.useRef();
+  const credentialRefs = {
+    oAuth: {
+      clientId: React.useRef(null),
+      clientSecret: React.useRef(null),
+      url: React.useRef(null),
+    },
+    basic: {
+      username: React.useRef(null),
+      password: React.useRef(null),
+    },
+  };
   const [requestInputSchema, setRequestInputSchema] = React.useState({});
+  const [credentialsType, setCredentialsType] = React.useState(
+    CREDENTIAL_TYPE_NONE,
+  );
 
   const handleSchemaChange = schema => {
     try {
@@ -50,10 +69,12 @@ export default function CreateApiPackageForm({
 
   const handleFormSubmit = async () => {
     const apiName = name.current.value;
+    const credentials = getCredentialsRefsValue(credentialRefs);
     const input = {
       name: apiName,
       description: description.current.value,
       instanceAuthRequestInputSchema: JSON.stringify(requestInputSchema),
+      defaultInstanceAuth: credentials,
     };
     try {
       await createApiPackage({
@@ -70,38 +91,60 @@ export default function CreateApiPackageForm({
   };
 
   return (
-    <form ref={formElementRef} onChange={onChange} onSubmit={handleFormSubmit}>
-      <FormItem key="name">
-        <FormLabel htmlFor="name" required={true}>
-          Name
-        </FormLabel>
-        <input
-          ref={name}
-          required={true}
-          id="name"
-          type="text"
-          placeholder="Name"
-          autoComplete="off"
-        />
-      </FormItem>
+    <form
+      ref={formElementRef}
+      onChange={onChange}
+      onSubmit={handleFormSubmit}
+      style={{ minHeight: '440px' }}
+    >
+      <TabGroup>
+        <Tab key="package-data" id="package-data" title="Data">
+          <FormItem key="name">
+            <FormLabel htmlFor="name" required={true}>
+              Name
+            </FormLabel>
+            <input
+              ref={name}
+              required={true}
+              id="name"
+              type="text"
+              placeholder="Name"
+              autoComplete="off"
+            />
+          </FormItem>
 
-      <FormItem key="description">
-        <FormLabel htmlFor="description">Description</FormLabel>
-        <input
-          ref={description}
-          id="description"
-          type="text"
-          placeholder="Description"
-          autoComplete="off"
-        />
-      </FormItem>
+          <FormItem key="description">
+            <FormLabel htmlFor="description">Description</FormLabel>
+            <input
+              ref={description}
+              id="description"
+              type="text"
+              placeholder="Description"
+              autoComplete="off"
+            />
+          </FormItem>
 
-      <FormLabel>Request input schema</FormLabel>
-      <JSONEditor
-        aria-label="schema-editor"
-        onChangeText={handleSchemaChange}
-        text={JSON.stringify(requestInputSchema, null, 2)}
-      />
+          <FormLabel>Request input schema</FormLabel>
+          <JSONEditor
+            aria-label="schema-editor"
+            onChangeText={handleSchemaChange}
+            text={JSON.stringify(requestInputSchema, null, 2)}
+          />
+        </Tab>
+        <Tab
+          key="package-credentials"
+          id="package-credentials"
+          title="Credentials"
+        >
+          <FormSet>
+            <CredentialsForm
+              credentialRefs={credentialRefs}
+              credentialType={credentialsType}
+              setCredentialType={setCredentialsType}
+            />
+          </FormSet>
+        </Tab>
+      </TabGroup>
     </form>
   );
 }

--- a/core-ui/src/components/ApiPackages/CreateApiPackageForm/test/CreateApiPackageForm.test.js
+++ b/core-ui/src/components/ApiPackages/CreateApiPackageForm/test/CreateApiPackageForm.test.js
@@ -3,7 +3,15 @@ import { MockedProvider } from '@apollo/react-testing';
 import { fireEvent, render, wait } from '@testing-library/react';
 import CreateApiPackageForm from '../CreateApiPackageForm';
 
-import { createApiPackageMock, refetchApiPackageMock } from './mocks';
+import {
+  apiPackageMock,
+  createApiPackageMock,
+  refetchApiPackageMock,
+  createApiPackageMockWithBasic,
+  createApiPackageMockWithOAuth,
+  basicCredentialsMock,
+  oAuthCredentialsMock,
+} from './mocks';
 
 jest.mock('@kyma-project/common', () => ({
   getApiUrl: () => 'kyma.local',
@@ -20,9 +28,7 @@ jest.mock('react-shared', () => ({
   JSONEditor: () => null,
 }));
 describe('CreateApiPackageForm', () => {
-  it('Sends request and shows notification on form submit', async () => {
-    console.warn = jest.fn(); // componentWillUpdate on JSONEditorComponent
-
+  it('Sends request and shows notification on form submit with no credentials', async () => {
     const formRef = React.createRef();
     const completedCallback = jest.fn();
 
@@ -42,10 +48,103 @@ describe('CreateApiPackageForm', () => {
     );
 
     fireEvent.change(getByLabelText(/Name/), {
-      target: { value: 'api-package-name' },
+      target: { value: apiPackageMock.name },
     });
     fireEvent.change(getByLabelText('Description'), {
-      target: { value: 'api-package-description' },
+      target: { value: apiPackageMock.description },
+    });
+
+    // simulate form submit from outside
+    formRef.current.dispatchEvent(new Event('submit'));
+
+    await wait(() => expect(completedCallback).toHaveBeenCalled());
+  });
+
+  it('Sends request and shows notification on form submit with Basic credentials', async () => {
+    console.error = jest.fn(); // Warning: `NaN` is an invalid value for the `left` css style property.
+
+    const formRef = React.createRef();
+    const completedCallback = jest.fn();
+
+    const { getByLabelText, getByText } = render(
+      <MockedProvider
+        mocks={[createApiPackageMockWithBasic, refetchApiPackageMock]}
+        addTypename={false}
+      >
+        <CreateApiPackageForm
+          applicationId="app-id"
+          formElementRef={formRef}
+          onChange={() => {}}
+          onCompleted={completedCallback}
+          onError={() => {}}
+        />
+      </MockedProvider>,
+    );
+
+    fireEvent.change(getByLabelText(/Name/), {
+      target: { value: apiPackageMock.name },
+    });
+    fireEvent.change(getByLabelText('Description'), {
+      target: { value: apiPackageMock.description },
+    });
+
+    fireEvent.click(getByText('Credentials')); // select tab
+    fireEvent.click(getByText('None')); // open dropdown
+    fireEvent.click(getByText('Basic')); // select credentials type
+
+    fireEvent.change(getByLabelText(/Username/), {
+      target: { value: basicCredentialsMock.username },
+    });
+    fireEvent.change(getByLabelText(/Password/), {
+      target: { value: basicCredentialsMock.password },
+    });
+
+    // simulate form submit from outside
+    formRef.current.dispatchEvent(new Event('submit'));
+
+    await wait(() => expect(completedCallback).toHaveBeenCalled());
+  });
+
+  it('Sends request and shows notification on form submit with OAuth credentials', async () => {
+    console.error = jest.fn(); // Warning: `NaN` is an invalid value for the `left` css style property.
+
+    const formRef = React.createRef();
+    const completedCallback = jest.fn();
+
+    const { getByLabelText, getByText } = render(
+      <MockedProvider
+        mocks={[createApiPackageMockWithOAuth, refetchApiPackageMock]}
+        addTypename={false}
+      >
+        <CreateApiPackageForm
+          applicationId="app-id"
+          formElementRef={formRef}
+          onChange={() => {}}
+          onCompleted={completedCallback}
+          onError={() => {}}
+        />
+      </MockedProvider>,
+    );
+
+    fireEvent.change(getByLabelText(/Name/), {
+      target: { value: apiPackageMock.name },
+    });
+    fireEvent.change(getByLabelText('Description'), {
+      target: { value: apiPackageMock.description },
+    });
+
+    fireEvent.click(getByText('Credentials')); // select tab
+    fireEvent.click(getByText('None')); // open dropdown
+    fireEvent.click(getByText('OAuth')); // select credentials type
+
+    fireEvent.change(getByLabelText(/Client ID/), {
+      target: { value: oAuthCredentialsMock.clientId },
+    });
+    fireEvent.change(getByLabelText(/Client Secret/), {
+      target: { value: oAuthCredentialsMock.clientSecret },
+    });
+    fireEvent.change(getByLabelText(/Url/), {
+      target: { value: oAuthCredentialsMock.url },
     });
 
     // simulate form submit from outside

--- a/core-ui/src/components/ApiPackages/CreateApiPackageForm/test/mocks.js
+++ b/core-ui/src/components/ApiPackages/CreateApiPackageForm/test/mocks.js
@@ -1,15 +1,69 @@
 import { CREATE_API_PACKAGE } from './../../gql';
 import { GET_APPLICATION_COMPASS } from 'gql/queries';
 
+export const apiPackageMock = {
+  name: 'api-package-name',
+  description: 'api-package-description',
+  instanceAuthRequestInputSchema: '{}',
+  defaultInstanceAuth: null,
+};
+
+export const basicCredentialsMock = {
+  username: 'basic-username',
+  password: 'basic-password',
+};
+
+export const oAuthCredentialsMock = {
+  clientId: 'clientId',
+  clientSecret: 'clientSecret',
+  url: 'https://test',
+};
+
 export const createApiPackageMock = {
   request: {
     query: CREATE_API_PACKAGE,
     variables: {
       applicationId: 'app-id',
+      in: apiPackageMock,
+    },
+  },
+  result: {
+    data: {
+      addPackage: {
+        name: 'package',
+      },
+    },
+  },
+};
+
+export const createApiPackageMockWithBasic = {
+  request: {
+    query: CREATE_API_PACKAGE,
+    variables: {
+      applicationId: 'app-id',
       in: {
-        name: 'api-package-name',
-        description: 'api-package-description',
-        instanceAuthRequestInputSchema: '{}',
+        ...apiPackageMock,
+        defaultInstanceAuth: { credential: { basic: basicCredentialsMock } },
+      },
+    },
+  },
+  result: {
+    data: {
+      addPackage: {
+        name: 'package',
+      },
+    },
+  },
+};
+
+export const createApiPackageMockWithOAuth = {
+  request: {
+    query: CREATE_API_PACKAGE,
+    variables: {
+      applicationId: 'app-id',
+      in: {
+        ...apiPackageMock,
+        defaultInstanceAuth: { credential: { oauth: oAuthCredentialsMock } },
       },
     },
   },
@@ -33,6 +87,10 @@ export const refetchApiPackageMock = {
     data: {
       application: {
         id: 'app-id',
+        name: 'app-name',
+        description: '',
+        providerName: '',
+        packages: [],
       },
     },
   },

--- a/core-ui/src/gql/queries.js
+++ b/core-ui/src/gql/queries.js
@@ -252,6 +252,21 @@ export const GET_API_PACKAGE = gql`
         name
         description
         instanceAuthRequestInputSchema
+        defaultInstanceAuth {
+          credential {
+            ... on OAuthCredentialData {
+              clientId
+              clientSecret
+              url
+              __typename
+            }
+            ... on BasicCredentialData {
+              username
+              password
+              __typename
+            }
+          }
+        }
         instanceAuths {
           id
           context


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `IntrospectionFragmentMatcher` to allow multiple `...on` fragments
- Add default credentials to API Package

**Related issue(s)**
