### PR TITLE
Ignore tenant header when calling compass from runtime

### DIFF
--- a/compass/src/store/index.js
+++ b/compass/src/store/index.js
@@ -28,12 +28,15 @@ export function createApolloClient(tenant, token) {
     uri: COMPASS_GRAPHQL_ENDPOINT,
   });
   const authLink = setContext((_, { headers }) => {
+    const headersVal = {
+      ...headers,
+      authorization: token,
+    };
+    if (tenant && tenant !== '') {
+      headersVal.tenant = tenant;
+    }
     return {
-      headers: {
-        ...headers,
-        tenant,
-        authorization: token,
-      },
+      headers: headersVal,
     };
   });
   const authHttpLink = authLink.concat(httpLink);

--- a/core-ui/src/apollo.js
+++ b/core-ui/src/apollo.js
@@ -38,16 +38,19 @@ export function createCompassApolloClient() {
   });
 
   const graphqlApiUrl = getURL('compassApiUrl');
-
-  //TODO: should be removed once management plane API is able to resolve tenant from token
   const tenant = getURL('compassDefaultTenant');
+
+  const headers = {
+    authorization: builder.getBearerToken() || null,
+  };
+
+  if (tenant && tenant !== '') {
+    headers.tenant = tenant;
+  }
 
   const httpLink = new HttpLink({
     uri: graphqlApiUrl,
-    headers: {
-      authorization: builder.getBearerToken() || null,
-      tenant,
-    },
+    headers,
   });
 
   return new ApolloClient({


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Do not send tenant header when calling compass from runtime

**Related issue(s)**
https://github.com/kyma-project/console/issues/1658
