### PR TITLE
Fix rendering of Async API documentation in service catalog UI

### DIFF
--- a/service-catalog-ui/nginx.conf
+++ b/service-catalog-ui/nginx.conf
@@ -36,9 +36,9 @@ http {
         add_header Access-Control-Allow-Origin *;
         add_header X-Content-Type-Options 'nosniff';
         add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
-        add_header X-XSS-Protection '1; mode=block';
+        # add_header X-XSS-Protection '1; mode=block';
         add_header X-Frame-Options 'SAMEORIGIN';
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
+        # add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
     }
 
     location /status {

--- a/service-catalog-ui/nginx.conf
+++ b/service-catalog-ui/nginx.conf
@@ -35,10 +35,10 @@ http {
         add_header 'Cache-Control' 'public, max-age=300';
         add_header Access-Control-Allow-Origin *;
         add_header X-Content-Type-Options 'nosniff';
-        add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
+        # add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
         # add_header X-XSS-Protection '1; mode=block';
         add_header X-Frame-Options 'SAMEORIGIN';
-        # add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
     }
 
     location /status {

--- a/service-catalog-ui/nginx.conf
+++ b/service-catalog-ui/nginx.conf
@@ -35,10 +35,10 @@ http {
         add_header 'Cache-Control' 'public, max-age=300';
         add_header Access-Control-Allow-Origin *;
         add_header X-Content-Type-Options 'nosniff';
-        # add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
-        # add_header X-XSS-Protection '1; mode=block';
-        add_header X-Frame-Options 'SAMEORIGIN';
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
+        add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
+        add_header X-XSS-Protection '1; mode=block';
+        # add_header X-Frame-Options 'SAMEORIGIN';
+        # add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
     }
 
     location /status {

--- a/service-catalog-ui/nginx.conf
+++ b/service-catalog-ui/nginx.conf
@@ -37,8 +37,8 @@ http {
         add_header X-Content-Type-Options 'nosniff';
         add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
         add_header X-XSS-Protection '1; mode=block';
-        # add_header X-Frame-Options 'SAMEORIGIN';
-        # add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
+        add_header X-Frame-Options 'SAMEORIGIN';
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
     }
 
     location /status {

--- a/service-catalog-ui/nginx.conf
+++ b/service-catalog-ui/nginx.conf
@@ -62,7 +62,7 @@ http {
         add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
         add_header X-XSS-Protection '1; mode=block';
         add_header X-Frame-Options 'SAMEORIGIN';
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
     }
 
     location /status {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Allow unsafe-eval (csp header) for `catalog` and `instances` nginx configurations  as required by generic documentation component 


