### PR TITLE
Fix schema validation in label editor

### DIFF
--- a/compass/nginx.conf
+++ b/compass/nginx.conf
@@ -43,7 +43,7 @@ http {
         add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
         add_header X-XSS-Protection '1; mode=block';
         add_header X-Frame-Options 'SAMEORIGIN';
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
     }
 
     location /status {

--- a/compass/nginx.conf
+++ b/compass/nginx.conf
@@ -43,7 +43,7 @@ http {
         add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
         add_header X-XSS-Protection '1; mode=block';
         add_header X-Frame-Options 'SAMEORIGIN';
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob: data:;";
     }
 
     location /status {

--- a/compass/nginx.conf
+++ b/compass/nginx.conf
@@ -43,7 +43,7 @@ http {
         add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
         add_header X-XSS-Protection '1; mode=block';
         add_header X-Frame-Options 'SAMEORIGIN';
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob: data:;";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob:;";
     }
 
     location /status {

--- a/compass/nginx.conf
+++ b/compass/nginx.conf
@@ -43,7 +43,7 @@ http {
         add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
         add_header X-XSS-Protection '1; mode=block';
         add_header X-Frame-Options 'SAMEORIGIN';
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob: data:;";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' data; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob: data:;";
     }
 
     location /status {

--- a/compass/nginx.conf
+++ b/compass/nginx.conf
@@ -43,7 +43,7 @@ http {
         add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains';
         add_header X-XSS-Protection '1; mode=block';
         add_header X-Frame-Options 'SAMEORIGIN';
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' data; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob: data:;";
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.$kymadomain wss://*.$kymadomain; font-src 'self' data:; frame-ancestors https://*.$kymadomain; object-src 'none'; media-src 'self'; form-action 'self'; img-src * data:; child-src * blob:; worker-src 'self' blob: data:;";
     }
 
     location /status {

--- a/compass/src/config/luigi-config/auth.js
+++ b/compass/src/config/luigi-config/auth.js
@@ -2,9 +2,14 @@ import OpenIdConnect from '@luigi-project/plugin-auth-oidc';
 import { clusterConfig } from './clusterConfig';
 
 async function fetchDexMetadata() {
-  const idpUrl = clusterConfig['defaultIdpIssuer'];
+  console.log(clusterConfig);
+  const domain = clusterConfig['domain'];
+  console.log(domain, `https://dex.${domain}/.well-known/openid-configuration`);
+
   try {
-    const response = await fetch(`${idpUrl}/.well-known/openid-configuration`);
+    const response = await fetch(
+      `https://dex.${domain}/.well-known/openid-configuration`,
+    );
     return await response.json();
   } catch (e) {
     alert('Cannot fetch dex metadata');

--- a/compass/src/config/luigi-config/auth.js
+++ b/compass/src/config/luigi-config/auth.js
@@ -2,9 +2,7 @@ import OpenIdConnect from '@luigi-project/plugin-auth-oidc';
 import { clusterConfig } from './clusterConfig';
 
 async function fetchDexMetadata() {
-  console.log(clusterConfig);
   const domain = clusterConfig['domain'];
-  console.log(domain, `https://dex.${domain}/.well-known/openid-configuration`);
 
   try {
     const response = await fetch(


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add CSP for scripts ('unsafe-inline' and data:)
- Use `domain` in place of `defaultIdpProvider`, as Compass has no access to latter.

**Related issue(s)**
