### PR TITLE
Handle empty event definitions

### DIFF
--- a/compass/src/components/Api/ApiDetails/ApiDetails.js
+++ b/compass/src/components/Api/ApiDetails/ApiDetails.js
@@ -88,18 +88,6 @@ const ApiDetails = ({ apiId, eventApiId, applicationId, apiPackageId }) => {
   const api =
     data.application.package[apiId ? 'apiDefinition' : 'eventDefinition'];
 
-  let specToShow = api.spec.data;
-
-  if (eventApiId) {
-    try {
-      const parsedSpec = JSON.parse(specToShow);
-      if (parsedSpec.asyncapi && parsedSpec.asyncapi.startsWith('1.')) {
-        specToShow = convert(specToShow, '2.0.0');
-      }
-    } catch (e) {
-      console.error('Error parsing async api spec', e);
-    }
-  }
   if (!api) {
     const resourceType = apiId ? 'API Definition' : 'Event Definition';
     return (
@@ -110,6 +98,19 @@ const ApiDetails = ({ apiId, eventApiId, applicationId, apiPackageId }) => {
         navigationContext="application"
       />
     );
+  }
+
+  let specToShow = api.spec ? api.spec.data : undefined;
+
+  if (eventApiId && specToShow) {
+    try {
+      const parsedSpec = JSON.parse(specToShow);
+      if (parsedSpec.asyncapi && parsedSpec.asyncapi.startsWith('1.')) {
+        specToShow = convert(specToShow, '2.0.0');
+      }
+    } catch (e) {
+      console.error('Error parsing async api spec', e);
+    }
   }
 
   return (

--- a/core-ui/src/components/Apis/ApiDetails/ApiDetails.js
+++ b/core-ui/src/components/Apis/ApiDetails/ApiDetails.js
@@ -100,19 +100,6 @@ const ApiDetails = ({ apiId, eventApiId, appId, apiPackageId }) => {
   const api =
     data.application.package[apiId ? 'apiDefinition' : 'eventDefinition'];
 
-  let specToShow = api.spec.data;
-
-  if (eventApiId) {
-    try {
-      const parsedSpec = JSON.parse(specToShow);
-      if (parsedSpec.asyncapi && parsedSpec.asyncapi.startsWith('1.')) {
-        specToShow = convert(specToShow, '2.0.0');
-      }
-    } catch (e) {
-      console.error('Error parsing async api spec', e);
-    }
-  }
-
   if (!api) {
     const resourceType = apiId ? 'API Definition' : 'Event Definition';
     return (
@@ -122,6 +109,19 @@ const ApiDetails = ({ apiId, eventApiId, appId, apiPackageId }) => {
         path={`/details/${appId}`}
       />
     );
+  }
+
+  let specToShow = api.spec ? api.spec.data : undefined;
+
+  if (eventApiId && specToShow) {
+    try {
+      const parsedSpec = JSON.parse(specToShow);
+      if (parsedSpec.asyncapi && parsedSpec.asyncapi.startsWith('1.')) {
+        specToShow = convert(specToShow, '2.0.0');
+      }
+    } catch (e) {
+      console.error('Error parsing async api spec', e);
+    }
   }
 
   function EditButton() {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix crashing event details view in case of empty spec

