### PR TITLE
Remove http2 directive from nginx configs

### DIFF
--- a/add-ons/nginx.conf
+++ b/add-ons/nginx.conf
@@ -30,7 +30,7 @@ http {
   server {
 
     server_name localhost;
-    listen 80 http2;
+    listen 80;
     root /var/public;
     port_in_redirect off;
 

--- a/compass/nginx.conf
+++ b/compass/nginx.conf
@@ -29,7 +29,7 @@ http {
 
   server {
     server_name localhost;
-    listen 8888 http2;
+    listen 8888;
     root /var/public;
     port_in_redirect off;
 
@@ -63,7 +63,7 @@ http {
 
   server {
     server_name localhost2;
-    listen 81 http2;
+    listen 81;
     root /var/public-luigi;
     port_in_redirect off;
 

--- a/content/nginx.conf
+++ b/content/nginx.conf
@@ -30,7 +30,7 @@ http {
   server {
 
     server_name localhost;
-    listen 80 http2;
+    listen 80;
     root /var/public;
     port_in_redirect off;
 

--- a/core-ui/nginx.conf
+++ b/core-ui/nginx.conf
@@ -29,7 +29,7 @@ http {
 
   server {
     server_name localhost;
-    listen 80 http2;
+    listen 80;
     root /var/public;
     port_in_redirect off;
 

--- a/core/nginx/nginx.conf
+++ b/core/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
     }
 
     server {
-        listen       8080 http2;
+        listen       8080;
         include      /usr/share/nginx-extended/nginx-*.conf;
 
         #charset koi8-r;

--- a/lambda/nginx/nginx.conf
+++ b/lambda/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
     }
 
     server {
-        listen       80 http2;
+        listen       80;
 
         #charset koi8-r;
         #access_log  /var/log/nginx/host.access.log  main;

--- a/logging/nginx.conf
+++ b/logging/nginx.conf
@@ -31,7 +31,7 @@ http {
     }
 
     server {
-        listen 80 http2;
+        listen 80;
         server_name  localhost;
 
         root   /var/public;

--- a/service-catalog-ui/nginx.conf
+++ b/service-catalog-ui/nginx.conf
@@ -26,7 +26,7 @@ http {
 
   server {
     server_name catalog;
-    listen 8080 http2;
+    listen 8080;
     root /var/catalog-public;
     port_in_redirect off;
 
@@ -50,7 +50,7 @@ http {
 
   server {
     server_name instances;
-    listen 8081 http2;
+    listen 8081;
     root /var/instances-public;
     port_in_redirect off;
 
@@ -74,7 +74,7 @@ http {
 
   server {
     server_name brokers;
-    listen 8082 http2;
+    listen 8082;
     root /var/brokers-public;
     port_in_redirect off;
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- remove http2 directive from nginx.confs as it implies SSL. SSL is handled by istio and it blocks k8s liveness probes which go straight to container without istio. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
