### PR TITLE
Do not show deprecated category in console navigation

### DIFF
--- a/core/src/app/content/settings/organisation/organisation.component.html
+++ b/core/src/app/content/settings/organisation/organisation.component.html
@@ -98,28 +98,5 @@
       </fd-panel-body>
     </fd-panel>
 
-    <fd-panel class="y-fd-panel">
-      <fd-panel-header>
-        <fd-panel-head>
-          <h2 fd-panel-title>Deprecated functionalities</h2>
-        </fd-panel-head>
-        <fd-panel-actions>
-          <div [dir]="'rtl'">
-            <fd-toggle
-              [(ngModel)]="showDeprecatedViews"
-              (change)="toggleDeprecatedViews()"
-              >Enable all
-            </fd-toggle>
-          </div>
-        </fd-panel-actions>
-      </fd-panel-header>
-      <fd-panel-body>
-        <p>
-          Enables all views which expose deprecated functionalities in the UI.<br> Refresh the page after enabling this option to see
-          additional navigation nodes in the
-          <strong>Deprecated</strong> category of the left navigation.
-        </p>
-      </fd-panel-body>
-    </fd-panel>
   </fd-panel-grid>
 </section>

--- a/core/src/app/content/settings/organisation/organisation.component.ts
+++ b/core/src/app/content/settings/organisation/organisation.component.ts
@@ -15,14 +15,11 @@ export class OrganisationComponent implements OnInit {
   public orgName: string;
   public showSystemNamespaces = false;
   public showExperimentalViews = false;
-  public showDeprecatedViews = false;
   public shouldShowNamespacesToggle = true;
 
   constructor(private http: HttpClient) {
     this.showExperimentalViews =
       localStorage.getItem('console.showExperimentalViews') === 'true';
-    this.showDeprecatedViews =
-      localStorage.getItem('console.showDeprecatedViews') === 'true';
   }
 
   public downloadKubeconfig() {
@@ -66,11 +63,6 @@ export class OrganisationComponent implements OnInit {
       },
       '*'
     );
-  }
-
-
-  public toggleDeprecatedViews() {
-    this.toggleViewVisibilityPreference('showDeprecatedViews');
   }
 
   public toggleExperimentalViews() {

--- a/core/src/luigi-config/navigation/microfrontend-converter.js
+++ b/core/src/luigi-config/navigation/microfrontend-converter.js
@@ -121,8 +121,6 @@ export default function convertToNavigationTree(
     .map(n => {
       const showExperimentalViews =
         localStorage.getItem('console.showExperimentalViews') === 'true';
-      const showDeprecatedViews =
-        localStorage.getItem('console.showDeprecatedViews') === 'true';
-      return hideByNodeCategory(n, showExperimentalViews, showDeprecatedViews);
+      return hideByNodeCategory(n, showExperimentalViews);
     });
 }

--- a/core/src/luigi-config/navigation/navigation-helpers.js
+++ b/core/src/luigi-config/navigation/navigation-helpers.js
@@ -85,11 +85,9 @@ export const getPreviousLocation = () => {
 };
 
 
-export function hideByNodeCategory(node, showExperimentalCategory, showDeprecatedCategory) {
+export function hideByNodeCategory(node, showExperimentalCategory) {
   if (node.category === "Experimental") {
     return { ...node, hideFromNav: !showExperimentalCategory };
-  } if (node.category === "Deprecated") {
-    return { ...node, hideFromNav: !showDeprecatedCategory };
   } else {
     return node;
   }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Do not use deprecated category for MFs. Do not show it

