### PR TITLE
Fix host url for API Rules defined with subdomain as host URL

### DIFF
--- a/core-ui/src/components/ApiRules/ApiRuleDetails/ApiRuleDetails.js
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/ApiRuleDetails.js
@@ -9,6 +9,7 @@ import { GET_API_RULE } from '../../../gql/queries';
 import { Spinner, PageHeader, CopiableLink } from 'react-shared';
 import { useDeleteApiRule } from '../useDeleteApiRule';
 import EntryNotFound from 'components/EntryNotFound/EntryNotFound';
+import { getApiUrl } from '@kyma-project/common';
 
 const ApiRuleDetails = ({ apiName }) => {
   const { error, loading, data } = useQuery(GET_API_RULE, {
@@ -94,6 +95,8 @@ function navigateToEditView(apiRuleName) {
 
 function ApiRuleDetailsHeader({ data }) {
   const host = `https://${data.service.host}`;
+  const DOMAIN = getApiUrl('domain');
+  let url = host.split(DOMAIN)[0] + `.${DOMAIN}`;
 
   const navigateToService = () =>
     LuigiClient.linkManager()
@@ -117,7 +120,7 @@ function ApiRuleDetailsHeader({ data }) {
         </span>
       </PageHeader.Column>
       <PageHeader.Column title="Host" columnSpan="2 / 4">
-        <CopiableLink url={host} />
+        <CopiableLink url={url} />
       </PageHeader.Column>
     </PageHeader>
   );

--- a/core-ui/src/components/ApiRules/ApiRuleDetails/ApiRuleDetails.js
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/ApiRuleDetails.js
@@ -96,7 +96,7 @@ function navigateToEditView(apiRuleName) {
 function ApiRuleDetailsHeader({ data }) {
   const host = `https://${data.service.host}`;
   const DOMAIN = getApiUrl('domain');
-  let url = host.split(`.${DOMAIN}`)[0] + `.${DOMAIN}`;
+  const url = host.split(`.${DOMAIN}`)[0] + `.${DOMAIN}`;
 
   const navigateToService = () =>
     LuigiClient.linkManager()

--- a/core-ui/src/components/ApiRules/ApiRuleDetails/ApiRuleDetails.js
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/ApiRuleDetails.js
@@ -96,7 +96,7 @@ function navigateToEditView(apiRuleName) {
 function ApiRuleDetailsHeader({ data }) {
   const host = `https://${data.service.host}`;
   const DOMAIN = getApiUrl('domain');
-  let url = host.split(DOMAIN)[0] + `.${DOMAIN}`;
+  let url = host.split(`.${DOMAIN}`)[0] + `.${DOMAIN}`;
 
   const navigateToService = () =>
     LuigiClient.linkManager()

--- a/core-ui/src/components/ApiRules/ApiRuleDetails/test/ApiRuleDetails.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/test/ApiRuleDetails.test.js
@@ -77,6 +77,10 @@ jest.mock('@kyma-project/luigi-client', () => ({
   }),
 }));
 
+jest.mock('@kyma-project/common', () => ({
+  getApiUrl: () => 'kyma.local',
+}));
+
 describe('ApiRuleDetails', () => {
   it('renders rule name', async () => {
     const { queryByText, container } = render(

--- a/core-ui/src/components/ApiRules/ApiRuleDetails/test/ApiRuleDetails.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/test/ApiRuleDetails.test.js
@@ -135,10 +135,13 @@ describe('ApiRuleDetails', () => {
     );
 
     await waitForDomChange(container);
-
-    const expectedHostUrl = `${apiRuleWithShortHost.service.host}.kyma.cluster.com`;
-
-    expect(queryByText(new RegExp(expectedHostUrl))).toBeInTheDocument();
+    expect(
+      queryByText(
+        new RegExp(
+          `${apiRuleWithShortHost.service.host}\\.kyma\\.cluster\\.com`,
+        ),
+      ),
+    ).toBeInTheDocument();
   });
 
   it('renders rule service', async () => {

--- a/core-ui/src/components/ApiRules/ApiRuleDetails/test/ApiRuleDetails.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/test/ApiRuleDetails.test.js
@@ -36,6 +36,15 @@ const apiRule = {
     },
   ],
 };
+const apiRuleWithShortHost = {
+  name: 'tets2',
+  service: {
+    name: 'tets-service',
+    host: 'tets',
+    port: 8080,
+  },
+  rules: [],
+};
 const mockNamespace = 'nsp';
 const validResponseMock = {
   request: {
@@ -45,6 +54,18 @@ const validResponseMock = {
   result: {
     data: {
       APIRule: apiRule,
+    },
+  },
+};
+
+const shortHostResponseMock = {
+  request: {
+    query: GET_API_RULE,
+    variables: { name: apiRuleWithShortHost.name, namespace: mockNamespace },
+  },
+  result: {
+    data: {
+      APIRule: apiRuleWithShortHost,
     },
   },
 };
@@ -104,6 +125,22 @@ describe('ApiRuleDetails', () => {
     await waitForDomChange(container);
 
     expect(queryByText(new RegExp(apiRule.service.host))).toBeInTheDocument();
+  });
+
+  it('renders auto-completed host url', async () => {
+    const { queryByText, container } = render(
+      <MockedProvider addTypename={false} mocks={[shortHostResponseMock]}>
+        <ApiRuleDetails apiName={apiRuleWithShortHost.name} />
+      </MockedProvider>,
+    );
+
+    await waitForDomChange(container);
+
+    expect(
+      queryByText(
+        new RegExp(`${apiRuleWithShortHost.service.host}.kyma.local`),
+      ),
+    ).toBeInTheDocument();
   });
 
   it('renders rule service', async () => {

--- a/core-ui/src/components/ApiRules/ApiRuleDetails/test/ApiRuleDetails.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/test/ApiRuleDetails.test.js
@@ -99,7 +99,7 @@ jest.mock('@kyma-project/luigi-client', () => ({
 }));
 
 jest.mock('@kyma-project/common', () => ({
-  getApiUrl: () => 'kyma.local',
+  getApiUrl: () => 'kyma.cluster.com',
 }));
 
 describe('ApiRuleDetails', () => {
@@ -136,11 +136,9 @@ describe('ApiRuleDetails', () => {
 
     await waitForDomChange(container);
 
-    expect(
-      queryByText(
-        new RegExp(`${apiRuleWithShortHost.service.host}.kyma.local`),
-      ),
-    ).toBeInTheDocument();
+    const expectedHostUrl = `${apiRuleWithShortHost.service.host}.kyma.cluster.com`;
+
+    expect(queryByText(new RegExp(expectedHostUrl))).toBeInTheDocument();
   });
 
   it('renders rule service', async () => {

--- a/core-ui/src/components/ApiRules/ApiRuleDetails/test/__snapshots__/ApiRuleDetails.test.js.snap
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/test/__snapshots__/ApiRuleDetails.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ApiRuleDetails Clicking on "Delete" deletes element 1`] = `Array []`;
+
 exports[`ApiRuleDetails renders breadcrumb 1`] = `
 Array [
   <li

--- a/core-ui/src/components/ApiRules/ApiRuleDetails/test/__snapshots__/ApiRuleDetails.test.js.snap
+++ b/core-ui/src/components/ApiRules/ApiRuleDetails/test/__snapshots__/ApiRuleDetails.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ApiRuleDetails Clicking on "Delete" deletes element 1`] = `Array []`;
-
 exports[`ApiRuleDetails renders breadcrumb 1`] = `
 Array [
   <li


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix the missing domain in the url that may happen if API Rule is defined with just a subdomain as a host url

**Related issue(s)**
https://github.com/kyma-project/kyma/pull/8155