### PR TITLE
Use "services" as default tab in Catalog and Instances

### DIFF
--- a/components/react/src/commons/instances-tab-utils.js
+++ b/components/react/src/commons/instances-tab-utils.js
@@ -1,6 +1,6 @@
 const indexTabNamePairs = [[0, 'addons'], [1, 'services']];
 
-const DEFAULT_TAB_NAME = 'addons';
+const DEFAULT_TAB_NAME = 'services';
 const DEFAULT_TAB_INDEX = 0;
 
 export function convertIndexToTabName(tabIndex = DEFAULT_TAB_INDEX) {

--- a/components/react/src/commons/instances-tab-utils.js
+++ b/components/react/src/commons/instances-tab-utils.js
@@ -1,4 +1,4 @@
-const indexTabNamePairs = [[0, 'addons'], [1, 'services']];
+const indexTabNamePairs = [[0, 'services'], [1, 'addons']];
 
 const DEFAULT_TAB_NAME = 'services';
 const DEFAULT_TAB_INDEX = 0;

--- a/components/react/src/components/Tabs/index.js
+++ b/components/react/src/components/Tabs/index.js
@@ -117,7 +117,7 @@ class Tabs extends React.Component {
         )}
         <TabsContent
           noMargin={props && props.noMargin}
-          wrapInPanel={props.wrapInPanel}
+          wrapInPanel={props && props.wrapInPanel}
         >
           {this.renderActiveTab(children)}
         </TabsContent>

--- a/service-catalog-ui/catalog/src/components/ServiceClassList/ServiceClassList.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassList/ServiceClassList.js
@@ -106,47 +106,6 @@ export default function ServiceClassList() {
           status={status(
             determineDisplayedServiceClasses(
               serviceClasses,
-              serviceClassConstants.addonsIndex,
-              searchQuery,
-              [],
-            ).length,
-            'addons-status',
-          )}
-          title={
-            <Tooltip
-              content={serviceClassConstants.addonsTooltipDescription}
-              minWidth="100px"
-              showTooltipTimeout={750}
-              key="catalog-addons-tab-tooltip"
-            >
-              {serviceClassConstants.addons}
-            </Tooltip>
-          }
-        >
-          <>
-            <ServiceClassDescription>
-              {serviceClassConstants.addonsDescription}
-            </ServiceClassDescription>
-            <ServiceClassListWrapper>
-              <CardsWrapper data-e2e-id="cards">
-                <Cards
-                  data-e2e-id="cards"
-                  items={determineDisplayedServiceClasses(
-                    serviceClasses,
-                    serviceClassConstants.addonsIndex,
-                    searchQuery,
-                    [],
-                  )}
-                />
-              </CardsWrapper>
-            </ServiceClassListWrapper>
-          </>
-        </Tab>
-        <Tab
-          noMargin
-          status={status(
-            determineDisplayedServiceClasses(
-              serviceClasses,
               serviceClassConstants.servicesIndex,
               searchQuery,
               [],
@@ -175,6 +134,47 @@ export default function ServiceClassList() {
                   items={determineDisplayedServiceClasses(
                     serviceClasses,
                     serviceClassConstants.servicesIndex,
+                    searchQuery,
+                    [],
+                  )}
+                />
+              </CardsWrapper>
+            </ServiceClassListWrapper>
+          </>
+        </Tab>
+        <Tab
+          noMargin
+          status={status(
+            determineDisplayedServiceClasses(
+              serviceClasses,
+              serviceClassConstants.addonsIndex,
+              searchQuery,
+              [],
+            ).length,
+            'addons-status',
+          )}
+          title={
+            <Tooltip
+              content={serviceClassConstants.addonsTooltipDescription}
+              minWidth="100px"
+              showTooltipTimeout={750}
+              key="catalog-addons-tab-tooltip"
+            >
+              {serviceClassConstants.addons}
+            </Tooltip>
+          }
+        >
+          <>
+            <ServiceClassDescription>
+              {serviceClassConstants.addonsDescription}
+            </ServiceClassDescription>
+            <ServiceClassListWrapper>
+              <CardsWrapper data-e2e-id="cards">
+                <Cards
+                  data-e2e-id="cards"
+                  items={determineDisplayedServiceClasses(
+                    serviceClasses,
+                    serviceClassConstants.addonsIndex,
                     searchQuery,
                     [],
                   )}

--- a/service-catalog-ui/catalog/src/components/ServiceClassList/test/ServiceClassList.test.js
+++ b/service-catalog-ui/catalog/src/components/ServiceClassList/test/ServiceClassList.test.js
@@ -13,6 +13,9 @@ import { Identifier } from 'fundamental-react';
 
 const mockNavigate = jest.fn();
 
+const servicesTabIndex = 0;
+const addonsTabIndex = 1;
+
 jest.mock('@kyma-project/luigi-client', () => ({
   getEventData: () => ({
     environmentId: mockEnvironmentId,
@@ -58,7 +61,7 @@ describe('ServiceClassList UI', () => {
 
   it('Add-Ons tab has proper counter', async () => {
     await componentUpdate(component);
-    const addOnsTab = component.find(Tab).at(0);
+    const addOnsTab = component.find(Tab).at(addonsTabIndex);
     expect(addOnsTab.find(Identifier).text()).toEqual(
       allServiceClassesQuery.result.data.serviceClasses.length.toString(),
     );
@@ -68,7 +71,7 @@ describe('ServiceClassList UI', () => {
 
   it('Services tab has proper counter', async () => {
     await componentUpdate(component);
-    const servicesTab = component.find(Tab).at(1);
+    const servicesTab = component.find(Tab).at(servicesTabIndex);
     expect(servicesTab.find(Identifier).text()).toEqual(
       allServiceClassesQuery.result.data.clusterServiceClasses.length.toString(),
     );
@@ -94,7 +97,7 @@ describe('ServiceClassList UI', () => {
 
     component
       .find(Tab)
-      .at(1)
+      .at(servicesTabIndex)
       .find('div')
       .first()
       .simulate('click');
@@ -174,7 +177,7 @@ describe('Search classes by other attributes', () => {
     });
     await componentUpdate(component);
 
-    const addOnsTab = component.find(Tab).at(0);
+    const addOnsTab = component.find(Tab).at(addonsTabIndex);
     expect(addOnsTab.find(Identifier).text()).toEqual('1');
 
     expectKnownConsoleWarnings();
@@ -188,7 +191,7 @@ describe('Search classes by other attributes', () => {
     search.simulate('change', { target: { value: searchedClass.description } });
     await componentUpdate(component);
 
-    const addOnsTab = component.find(Tab).at(0);
+    const addOnsTab = component.find(Tab).at(addonsTabIndex);
     expect(addOnsTab.find(Identifier).text()).toEqual('1');
 
     expectKnownConsoleWarnings();

--- a/service-catalog-ui/catalog/src/variables.js
+++ b/service-catalog-ui/catalog/src/variables.js
@@ -29,8 +29,8 @@ export const serviceClassConstants = {
     'An error occurred while loading Service Classes Variants List',
 
   //service class list tabs indices
-  addonsIndex: 0,
-  servicesIndex: 1,
+  servicesIndex: 0,
+  addonsIndex: 1,
 };
 
 export const serviceClassTabs = {

--- a/service-catalog-ui/instances/src/components/ServiceInstancesList/ServiceInstancesList.js
+++ b/service-catalog-ui/instances/src/components/ServiceInstancesList/ServiceInstancesList.js
@@ -173,41 +173,6 @@ export default function ServiceInstancesList() {
           status={status(
             determineDisplayedInstances(
               serviceInstances,
-              serviceInstanceConstants.addonsIndex,
-              searchQuery,
-              activeLabelFilters,
-            ).length,
-            'addons-status',
-          )}
-          title={
-            <Tooltip
-              content={serviceInstanceConstants.addonsTooltipDescription}
-              minWidth="100px"
-              showTooltipTimeout={750}
-              key="instances-addons-tab-tooltip"
-            >
-              {serviceInstanceConstants.addons}
-            </Tooltip>
-          }
-        >
-          <ServiceInstancesWrapper data-e2e-id="instances-wrapper">
-            <ServiceInstancesTable
-              data={determineDisplayedInstances(
-                serviceInstances,
-                serviceInstanceConstants.addonsIndex,
-                searchQuery,
-                activeLabelFilters,
-              )}
-              deleteServiceInstance={handleDelete}
-              type="addons"
-            />
-          </ServiceInstancesWrapper>
-        </Tab>
-        <Tab
-          noMargin
-          status={status(
-            determineDisplayedInstances(
-              serviceInstances,
               serviceInstanceConstants.servicesIndex,
               searchQuery,
               activeLabelFilters,
@@ -235,6 +200,41 @@ export default function ServiceInstancesList() {
               )}
               deleteServiceInstance={handleDelete}
               type="services"
+            />
+          </ServiceInstancesWrapper>
+        </Tab>
+        <Tab
+          noMargin
+          status={status(
+            determineDisplayedInstances(
+              serviceInstances,
+              serviceInstanceConstants.addonsIndex,
+              searchQuery,
+              activeLabelFilters,
+            ).length,
+            'addons-status',
+          )}
+          title={
+            <Tooltip
+              content={serviceInstanceConstants.addonsTooltipDescription}
+              minWidth="100px"
+              showTooltipTimeout={750}
+              key="instances-addons-tab-tooltip"
+            >
+              {serviceInstanceConstants.addons}
+            </Tooltip>
+          }
+        >
+          <ServiceInstancesWrapper data-e2e-id="instances-wrapper">
+            <ServiceInstancesTable
+              data={determineDisplayedInstances(
+                serviceInstances,
+                serviceInstanceConstants.addonsIndex,
+                searchQuery,
+                activeLabelFilters,
+              )}
+              deleteServiceInstance={handleDelete}
+              type="addons"
             />
           </ServiceInstancesWrapper>
         </Tab>

--- a/service-catalog-ui/instances/src/components/ServiceInstancesList/test/ServiceInstancesList.test.js
+++ b/service-catalog-ui/instances/src/components/ServiceInstancesList/test/ServiceInstancesList.test.js
@@ -27,6 +27,9 @@ const mockNavigate = jest.fn();
 const mockAddBackdrop = jest.fn();
 const mockRemoveBackdrop = jest.fn();
 
+const servicesTabIndex = 0;
+const addonsTabIndex = 1;
+
 function mountWithModalBg(component) {
   return mount(
     <div className="modal-demo-bg">
@@ -310,10 +313,10 @@ describe('Search instances by name', () => {
   it('Shows all instances initially', async () => {
     await componentUpdate(component);
 
-    const addOnsTab = component.find(Tab).at(0);
+    const addOnsTab = component.find(Tab).at(addonsTabIndex);
     expect(addOnsTab.find(Identifier).text()).toEqual('2');
 
-    const servicesTab = component.find(Tab).at(1);
+    const servicesTab = component.find(Tab).at(servicesTabIndex);
     expect(servicesTab.find(Identifier).text()).toEqual('1');
 
     expectKnownConsoleWarnings();
@@ -327,7 +330,7 @@ describe('Search instances by name', () => {
     search.simulate('change', { target: { value: 'motherly' } });
 
     await componentUpdate(component);
-    const addOnsTab = component.find(Tab).at(0);
+    const addOnsTab = component.find(Tab).at(addonsTabIndex);
     expect(addOnsTab.find(Identifier).text()).toEqual('1');
     addOnsTab
       .find('div')
@@ -338,7 +341,7 @@ describe('Search instances by name', () => {
       serviceInstance1,
     ]);
 
-    const servicesTab = component.find(Tab).at(1);
+    const servicesTab = component.find(Tab).at(servicesTabIndex);
     expect(servicesTab.find(Identifier).text()).toEqual('0');
 
     servicesTab
@@ -359,7 +362,7 @@ describe('Search instances by name', () => {
     search.simulate('change', { target: { value: 'fishing' } });
 
     await componentUpdate(component);
-    const addOnsTab = component.find(Tab).at(0);
+    const addOnsTab = component.find(Tab).at(addonsTabIndex);
     expect(addOnsTab.find(Identifier).text()).toEqual('0');
     addOnsTab
       .find('div')
@@ -368,7 +371,7 @@ describe('Search instances by name', () => {
     await componentUpdate(component);
     expect(component.find(ServiceInstancesTable).prop('data')).toEqual([]);
 
-    const servicesTab = component.find(Tab).at(1);
+    const servicesTab = component.find(Tab).at(servicesTabIndex);
     expect(servicesTab.find(Identifier).text()).toEqual('1');
 
     servicesTab
@@ -428,7 +431,7 @@ describe('filter instances by labels', () => {
       'label1',
     ]);
 
-    const addOnsTab = component.find(Tab).at(0);
+    const addOnsTab = component.find(Tab).at(addonsTabIndex);
     expect(addOnsTab.find(Identifier).text()).toEqual('1');
 
     addOnsTab
@@ -440,7 +443,7 @@ describe('filter instances by labels', () => {
       serviceInstance1,
     ]);
 
-    const servicesTab = component.find(Tab).at(1);
+    const servicesTab = component.find(Tab).at(servicesTabIndex);
     expect(servicesTab.find(Identifier).text()).toEqual('0');
 
     servicesTab

--- a/service-catalog-ui/instances/src/variables.js
+++ b/service-catalog-ui/instances/src/variables.js
@@ -27,8 +27,8 @@ export const serviceInstanceConstants = {
   error: 'Error',
 
   //instance list tabs indices
-  addonsIndex: 0,
-  servicesIndex: 1,
+  servicesIndex: 0,
+  addonsIndex: 1,
 };
 
 export const serviceInstanceTabs = {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use "services" as default tab

**Related issue(s)**
Fixes [345](https://github.tools.sap/kyma/backlog/issues/345)
