### PR TITLE
Support HEAD and PATCH methods in API Rule UI

### DIFF
--- a/core-ui/src/components/ApiRules/AccessStrategy/test/AccessStrategy.test.js
+++ b/core-ui/src/components/ApiRules/AccessStrategy/test/AccessStrategy.test.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import AccessStrategy from '../AccessStrategy';
 import { render } from '@testing-library/react';
+import { supportedMethodsList } from '../../accessStrategyTypes';
 
 const defaultAccessStrategy = {
   path: '/.*',
-  methods: ['GET', 'POST', 'PUT', 'DELETE'],
+  methods: supportedMethodsList,
   accessStrategies: [
     {
       name: 'noop',

--- a/core-ui/src/components/ApiRules/ApiRuleForm/AccessStrategyForm/AccessStrategyForm.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/AccessStrategyForm/AccessStrategyForm.js
@@ -17,6 +17,7 @@ import JwtDetails from './JwtDetails/JwtDetails';
 import classNames from 'classnames';
 import accessStrategyTypes, {
   usesMethods,
+  supportedMethodsList,
 } from 'components/ApiRules/accessStrategyTypes';
 
 export default function AccessStrategyForm({
@@ -156,7 +157,7 @@ function OAuth2Details({ config, setConfig }) {
 }
 
 function MethodsForm({ methods, setMethods, isRelevant }) {
-  const AVAILABLE_METHODS = ['GET', 'POST', 'PUT', 'DELETE'];
+  const AVAILABLE_METHODS = supportedMethodsList;
   const toggleMethod = function(method, checked) {
     if (checked) {
       setMethods([...methods, method]);

--- a/core-ui/src/components/ApiRules/ApiRuleForm/AccessStrategyForm/test/AccessStrategyForm.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/AccessStrategyForm/test/AccessStrategyForm.test.js
@@ -88,6 +88,8 @@ describe('AccessStrategyForm', () => {
     expect(getByLabelText('PUT')).toBeChecked();
     expect(getByLabelText('POST')).not.toBeChecked();
     expect(getByLabelText('DELETE')).not.toBeChecked();
+    expect(getByLabelText('HEAD')).not.toBeChecked();
+    expect(getByLabelText('PATCH')).not.toBeChecked();
   });
 
   it('renders OAuth2 strategy', () => {

--- a/core-ui/src/components/ApiRules/ApiRuleForm/test/ApiRuleForm.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/test/ApiRuleForm.test.js
@@ -56,6 +56,8 @@ describe('ApiRuleForm', () => {
     verifyMethodCheckboxes(queryAllByLabelText, 'PUT');
     verifyMethodCheckboxes(queryAllByLabelText, 'POST');
     verifyMethodCheckboxes(queryAllByLabelText, 'DELETE');
+    verifyMethodCheckboxes(queryAllByLabelText, 'HEAD');
+    verifyMethodCheckboxes(queryAllByLabelText, 'PATCH');
 
     const typeSelects = queryAllByLabelText('Access strategy type');
     expect(typeSelects).toHaveLength(apiRule().rules.length);

--- a/core-ui/src/components/ApiRules/ApiRuleForm/test/ApiRuleForm.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/test/ApiRuleForm.test.js
@@ -8,6 +8,7 @@ import {
   servicesQuery,
   idpPresetsQuery,
 } from './mocks';
+import { supportedMethodsList } from 'components/ApiRules/accessStrategyTypes';
 
 jest.mock('@kyma-project/common', () => ({
   getApiUrl: () => 'kyma.cluster.com',
@@ -52,12 +53,9 @@ describe('ApiRuleForm', () => {
       expect(input).toHaveValue(apiRule().rules[idx].path);
     });
 
-    verifyMethodCheckboxes(queryAllByLabelText, 'GET');
-    verifyMethodCheckboxes(queryAllByLabelText, 'PUT');
-    verifyMethodCheckboxes(queryAllByLabelText, 'POST');
-    verifyMethodCheckboxes(queryAllByLabelText, 'DELETE');
-    verifyMethodCheckboxes(queryAllByLabelText, 'HEAD');
-    verifyMethodCheckboxes(queryAllByLabelText, 'PATCH');
+    supportedMethodsList.forEach(method =>
+      verifyMethodCheckboxes(queryAllByLabelText, method),
+    );
 
     const typeSelects = queryAllByLabelText('Access strategy type');
     expect(typeSelects).toHaveLength(apiRule().rules.length);

--- a/core-ui/src/components/ApiRules/CreateApiRule/CreateApiRule.js
+++ b/core-ui/src/components/ApiRules/CreateApiRule/CreateApiRule.js
@@ -5,10 +5,11 @@ import { useNotification } from 'react-shared';
 import { CREATE_API_RULE } from '../../../gql/mutations';
 import ApiRuleForm from '../ApiRuleForm/ApiRuleForm';
 import LuigiClient from '@kyma-project/luigi-client';
+import { supportedMethodsList } from '../accessStrategyTypes';
 
 const DEFAULT_ACCESS_STRATEGY = {
   path: '/.*',
-  methods: ['GET', 'POST', 'PUT', 'DELETE'],
+  methods: supportedMethodsList,
   accessStrategies: [
     {
       name: 'noop',

--- a/core-ui/src/components/ApiRules/CreateApiRule/test/mocks.js
+++ b/core-ui/src/components/ApiRules/CreateApiRule/test/mocks.js
@@ -2,6 +2,7 @@ import { service1, service2 } from 'testing/servicesMocks';
 import { GET_SERVICES } from 'gql/queries';
 import { CREATE_API_RULE } from 'gql/mutations';
 import { EXCLUDED_SERVICES_LABELS } from 'components/ApiRules/constants';
+import { supportedMethodsList } from 'components/ApiRules/accessStrategyTypes';
 
 export const apiRuleName = 'test-123';
 export const mockNamespace = 'test';
@@ -22,7 +23,7 @@ export const sampleAPIRule = {
     rules: [
       {
         path: '/.*',
-        methods: ['GET', 'POST', 'PUT', 'DELETE'],
+        methods: supportedMethodsList,
         accessStrategies: [
           {
             name: 'noop',

--- a/core-ui/src/components/ApiRules/accessStrategyTypes.js
+++ b/core-ui/src/components/ApiRules/accessStrategyTypes.js
@@ -21,3 +21,12 @@ const accessStrategyTypes = { noop, allow, oauth2_introspection, jwt };
 export default accessStrategyTypes;
 export const usesMethods = strategyType =>
   !accessStrategyTypes[strategyType].methodsIrrelevant;
+
+export const supportedMethodsList = [
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+];


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Define supported method set in one place
- Add `HEAD` and `PATCH` methods

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/8392