### PR TITLE
Fix auth method dropdown in API Rules

### DIFF
--- a/core-ui/src/components/ApiRules/ApiRuleForm/ApiRuleForm.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/ApiRuleForm.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { v4 as uuid } from 'uuid';
 import { useQuery } from '@apollo/react-hooks';
 import LuigiClient from '@kyma-project/luigi-client';
 import { K8sNameInput, InputWithSuffix } from 'react-shared';
@@ -57,7 +58,10 @@ export default function ApiRuleForm({
   breadcrumbItems,
 }) {
   const namespace = LuigiClient.getEventData().environmentId;
-  const [rules, setRules] = useState(apiRule.rules);
+  const [rules, setRules] = useState(
+    apiRule.rules.map(r => ({ ...r, renderKey: uuid() })),
+  );
+
   const [isValid, setValid] = useState(false);
   const { serviceName, port } = LuigiClient.getNodeParams();
 
@@ -121,14 +125,17 @@ export default function ApiRuleForm({
         serviceName,
         servicePort,
         gateway: DEFAULT_GATEWAY,
-        rules: rules,
+        rules: rules.map(({ renderKey, ...actualRule }) => actualRule),
       },
     };
     mutation({ variables });
   }
 
   function addAccessStrategy() {
-    setRules(rules => [...rules, EMPTY_ACCESS_STRATEGY]);
+    setRules(rules => [
+      ...rules,
+      { ...EMPTY_ACCESS_STRATEGY, renderKey: uuid() },
+    ]);
     setValid(false);
   }
 
@@ -222,7 +229,7 @@ export default function ApiRuleForm({
                   {rules.map((rule, idx) => {
                     return (
                       <AccessStrategyForm
-                        key={idx}
+                        key={rule.renderKey}
                         strategy={rule}
                         setStrategy={newStrategy => {
                           setRules(rules => [

--- a/core-ui/src/components/ApiRules/ApiRuleForm/ServicesDropdown/test/ServicesDropdown.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/ServicesDropdown/test/ServicesDropdown.test.js
@@ -12,7 +12,7 @@ describe('ServicesDropdown', () => {
         _ref={ref}
         error={undefined}
         loading={true}
-        data={[]}
+        data={{}}
       />,
     );
 
@@ -25,7 +25,7 @@ describe('ServicesDropdown', () => {
         _ref={ref}
         error={new Error('Error')}
         loading={false}
-        data={[]}
+        data={{}}
       />,
     );
     expect(

--- a/core-ui/src/components/ApiRules/ApiRuleForm/test/ApiRuleForm.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/test/ApiRuleForm.test.js
@@ -151,6 +151,31 @@ describe('ApiRuleForm', () => {
     });
   });
 
+  it('does not modify other strategies after removing one', async () => {
+    const mutation = jest.fn();
+    const rule = apiRule();
+    const { getAllByLabelText, container } = render(
+      <MockedProvider mocks={[servicesQuery, idpPresetsQuery]}>
+        <ApiRuleForm
+          apiRule={rule}
+          mutation={mutation}
+          saveButtonText="Save"
+          headerTitle="Form"
+          breadcrumbItems={[]}
+        />
+      </MockedProvider>,
+    );
+    await waitForDomChange({ container });
+
+    getAllByLabelText('remove-access-strategy')[0].click();
+
+    await waitForDomChange({ container });
+
+    const strategySelects = getAllByLabelText('Access strategy type');
+    const nonRemovedRule = rule.rules[1].accessStrategies[0];
+    expect(strategySelects[0].value).toBe(nonRemovedRule.name);
+  });
+
   it('allows to modify exisitng access strategy', async () => {
     const mutation = jest.fn();
     const { getAllByLabelText, getByText, container } = render(

--- a/core-ui/src/components/ApiRules/ApiRuleForm/test/mocks.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/test/mocks.js
@@ -25,10 +25,10 @@ export const apiRule = () => ({
     },
     {
       path: '/bbb',
-      methods: ['POST', 'DELETE'],
+      methods: [],
       accessStrategies: [
         {
-          name: 'noop',
+          name: 'allow',
         },
       ],
     },


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add test covering the problem
- Fix actual #1739 
- Fix prop in `ServiceDropdown` test

**What's more**

Using array indices as React `key`s was the root of the problem. Actually, it's considered as [an antipattern](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318).
As `strategy` does not contain any id-like field, I decided to use additional property `renderKey`, set to random UUID.

**Related issue(s)**
[1739](https://github.com/kyma-project/console/issues/1739)