### PR TITLE
Improve settings view

### DIFF
--- a/core/src/app/app.module.ts
+++ b/core/src/app/app.module.ts
@@ -49,7 +49,7 @@ import { ServiceDetailsComponent } from './content/namespaces/operation/services
 import { ServicesEntryRendererComponent } from './content/namespaces/operation/services/services-entry-renderer/services-entry-renderer.component';
 import { ServicesHeaderRendererComponent } from './content/namespaces/operation/services/services-header-renderer/services-header-renderer.component';
 import { ServicesComponent } from './content/namespaces/operation/services/services.component';
-import { SettingsComponent } from './content/settings/settings/settings.component';
+import { PreferencesComponent } from './content/settings/preferences/preferences.component';
 import { EditBindingsModalComponent } from './content/settings/applications/application-details/edit-bindings-modal/edit-binding-modal.component';
 import { BindingsDetailsModalComponent } from './content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component';
 import { CreateBindingsModalComponent } from './content/settings/applications/application-details/create-bindings-modal/create-binding-modal.component';
@@ -137,7 +137,7 @@ import * as LuigiClient from '@luigi-project/client';
     TimeAgoPipe,
     ApplicationsComponent,
     ApplicationDetailsComponent,
-    SettingsComponent,
+    PreferencesComponent,
     NamespaceDetailsComponent,
     ServiceBrokersComponent,
     ReplicaSetsComponent,

--- a/core/src/app/app.module.ts
+++ b/core/src/app/app.module.ts
@@ -49,7 +49,7 @@ import { ServiceDetailsComponent } from './content/namespaces/operation/services
 import { ServicesEntryRendererComponent } from './content/namespaces/operation/services/services-entry-renderer/services-entry-renderer.component';
 import { ServicesHeaderRendererComponent } from './content/namespaces/operation/services/services-header-renderer/services-header-renderer.component';
 import { ServicesComponent } from './content/namespaces/operation/services/services.component';
-import { OrganisationComponent } from './content/settings/organisation/organisation.component';
+import { SettingsComponent } from './content/settings/settings/settings.component';
 import { EditBindingsModalComponent } from './content/settings/applications/application-details/edit-bindings-modal/edit-binding-modal.component';
 import { BindingsDetailsModalComponent } from './content/settings/applications/application-details/bindings-details-modal/bindings-details-modal.component';
 import { CreateBindingsModalComponent } from './content/settings/applications/application-details/create-bindings-modal/create-binding-modal.component';
@@ -137,7 +137,7 @@ import * as LuigiClient from '@luigi-project/client';
     TimeAgoPipe,
     ApplicationsComponent,
     ApplicationDetailsComponent,
-    OrganisationComponent,
+    SettingsComponent,
     NamespaceDetailsComponent,
     ServiceBrokersComponent,
     ReplicaSetsComponent,

--- a/core/src/app/content/settings/preferences/preferences.component.html
+++ b/core/src/app/content/settings/preferences/preferences.component.html
@@ -1,30 +1,13 @@
 <header class="fd-page__header fd-has-background-color-background-2">
   <section class="fd-section">
     <div class="fd-section__header">
-      <h1 class="fd-section__title">Settings</h1>
+      <h1 class="fd-section__title">Preferences</h1>
     </div>
   </section>
 </header>
 
 <section class="fd-section">
   <fd-panel-grid [col]="1">
-    <fd-panel class="y-fd-panel">
-      <fd-panel-header>
-        <fd-panel-head>
-          <h2 fd-panel-title>Kubeconfig</h2>
-        </fd-panel-head>
-      </fd-panel-header>
-      <fd-panel-body>
-        <p class="fd-has-type fd-has-color-text-3 fd-has-font-style-italic">
-          kubeconfig is a file used to configure access to a cluster. Download
-          it to access the cluster using command line.
-        </p>
-        <button fd-button [glyph]="'download'" (click)="downloadKubeconfig()">
-          Download config
-        </button>
-      </fd-panel-body>
-    </fd-panel>
-
     <fd-panel *ngIf="shouldShowNamespacesToggle" class="y-fd-panel">
       <fd-panel-header>
         <fd-panel-head>

--- a/core/src/app/content/settings/preferences/preferences.component.ts
+++ b/core/src/app/content/settings/preferences/preferences.component.ts
@@ -1,32 +1,20 @@
 import { Component, OnInit } from '@angular/core';
 import { AppConfig } from '../../../app.config';
-import { HttpClient } from '@angular/common/http';
-import * as FileSaver from 'file-saver';
 import { SHOW_SYSTEM_NAMESPACES_CHANGED_EVENT } from '../../../shared/constants/constants';
 import LuigiClient from '@luigi-project/client';
 
 @Component({
-  selector: 'app-settings',
-  templateUrl: './settings.component.html'
+  selector: 'app-preferences',
+  templateUrl: './preferences.component.html'
 })
-export class SettingsComponent implements OnInit {
+export class PreferencesComponent implements OnInit {
   public showSystemNamespaces = false;
   public showExperimentalViews = false;
   public shouldShowNamespacesToggle = true;
 
-  constructor(private http: HttpClient) {
+  constructor() {
     this.showExperimentalViews =
       localStorage.getItem('console.showExperimentalViews') === 'true';
-  }
-
-  public downloadKubeconfig() {
-    return this.http
-      .get(AppConfig.kubeconfigGeneratorUrl, {
-        responseType: 'blob'
-      })
-      .subscribe(res => {
-        FileSaver.saveAs(res, 'kubeconfig');
-      });
   }
 
   ngOnInit() {

--- a/core/src/app/content/settings/settings/settings.component.html
+++ b/core/src/app/content/settings/settings/settings.component.html
@@ -1,45 +1,13 @@
 <header class="fd-page__header fd-has-background-color-background-2">
   <section class="fd-section">
     <div class="fd-section__header">
-      <h1 class="fd-section__title">Your Organisation</h1>
+      <h1 class="fd-section__title">Settings</h1>
     </div>
   </section>
 </header>
 
 <section class="fd-section">
   <fd-panel-grid [col]="1">
-    <fd-panel class="y-fd-panel">
-      <fd-panel-body>
-        <fieldset fd-form-set class="fd-col--6">
-          <fd-form-group>
-            <div fd-form-item>
-              <label fd-form-label>Name</label>
-              <input
-                fd-form-control
-                [type]="'text'"
-                placeholder="Function name"
-                value="{{ orgName }}"
-                readonly
-              />
-            </div>
-          </fd-form-group>
-        </fieldset>
-        <fieldset fd-form-set class="fd-col--6">
-          <fd-form-group>
-            <div fd-form-item>
-              <label fd-form-label>Org-ID</label>
-              <input
-                fd-form-control
-                [type]="'text'"
-                value="{{ orgId }}"
-                readonly
-              />
-            </div>
-          </fd-form-group>
-        </fieldset>
-      </fd-panel-body>
-    </fd-panel>
-
     <fd-panel class="y-fd-panel">
       <fd-panel-header>
         <fd-panel-head>

--- a/core/src/app/content/settings/settings/settings.component.ts
+++ b/core/src/app/content/settings/settings/settings.component.ts
@@ -2,17 +2,14 @@ import { Component, OnInit } from '@angular/core';
 import { AppConfig } from '../../../app.config';
 import { HttpClient } from '@angular/common/http';
 import * as FileSaver from 'file-saver';
-import { SHOW_SYSTEM_NAMESPACES_CHANGED_EVENT } from './../../../shared/constants/constants';
+import { SHOW_SYSTEM_NAMESPACES_CHANGED_EVENT } from '../../../shared/constants/constants';
 import LuigiClient from '@luigi-project/client';
 
 @Component({
-  selector: 'app-organisation',
-  templateUrl: './organisation.component.html',
-  styleUrls: ['./organisation.component.scss']
+  selector: 'app-settings',
+  templateUrl: './settings.component.html'
 })
-export class OrganisationComponent implements OnInit {
-  public orgId: string;
-  public orgName: string;
+export class SettingsComponent implements OnInit {
   public showSystemNamespaces = false;
   public showExperimentalViews = false;
   public shouldShowNamespacesToggle = true;
@@ -33,9 +30,6 @@ export class OrganisationComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.orgId = AppConfig.orgId;
-    this.orgName = AppConfig.orgName;
-
     const groups = LuigiClient.getContext().groups;
     this.shouldShowNamespacesToggle = this.isVisibleForCurrentGroup(groups);
 

--- a/core/src/app/navigation/app-routing.module.ts
+++ b/core/src/app/navigation/app-routing.module.ts
@@ -12,7 +12,7 @@ import { SecretDetailComponent } from '../content/namespaces/operation/secrets/s
 import { SecretsComponent } from '../content/namespaces/operation/secrets/secrets.component';
 import { ServiceDetailsComponent } from '../content/namespaces/operation/services/service-details/service-details.component';
 import { ServicesComponent } from '../content/namespaces/operation/services/services.component';
-import { OrganisationComponent } from '../content/settings/organisation/organisation.component';
+import { SettingsComponent } from '../content/settings/settings/settings.component';
 import { ApplicationDetailsComponent } from '../content/settings/applications/application-details/application-details.component';
 import { ApplicationsComponent } from '../content/settings/applications/applications.component';
 import { ServiceBrokersComponent } from '../content/settings/service-brokers/service-brokers.component';
@@ -93,8 +93,8 @@ const appRoutes: Routes = [
         component: NamespacesContainerComponent,
         data: { navCtx: 'settings' },
         children: [
-          { path: 'yVirtual', component: OrganisationComponent },
-          { path: 'organisation', component: OrganisationComponent },
+          { path: 'yVirtual', component: SettingsComponent },
+          { path: 'settings', component: SettingsComponent },
           { path: 'apps', component: ApplicationsComponent },
           {
             path: 'apps/:id',
@@ -112,8 +112,8 @@ const appRoutes: Routes = [
             component: RoleDetailsComponent,
             data: { global: true }
           },
-          { path: '', redirectTo: 'organisation', pathMatch: 'full' },
-          { path: '**', redirectTo: 'organisation', pathMatch: 'full' }
+          { path: '', redirectTo: 'settings', pathMatch: 'full' },
+          { path: '**', redirectTo: 'settings', pathMatch: 'full' }
         ]
       },
       { path: '', pathMatch: 'full', redirectTo: 'namespaces/workspace' },

--- a/core/src/app/navigation/app-routing.module.ts
+++ b/core/src/app/navigation/app-routing.module.ts
@@ -12,7 +12,7 @@ import { SecretDetailComponent } from '../content/namespaces/operation/secrets/s
 import { SecretsComponent } from '../content/namespaces/operation/secrets/secrets.component';
 import { ServiceDetailsComponent } from '../content/namespaces/operation/services/service-details/service-details.component';
 import { ServicesComponent } from '../content/namespaces/operation/services/services.component';
-import { SettingsComponent } from '../content/settings/settings/settings.component';
+import { PreferencesComponent } from '../content/settings/preferences/preferences.component';
 import { ApplicationDetailsComponent } from '../content/settings/applications/application-details/application-details.component';
 import { ApplicationsComponent } from '../content/settings/applications/applications.component';
 import { ServiceBrokersComponent } from '../content/settings/service-brokers/service-brokers.component';
@@ -93,8 +93,8 @@ const appRoutes: Routes = [
         component: NamespacesContainerComponent,
         data: { navCtx: 'settings' },
         children: [
-          { path: 'yVirtual', component: SettingsComponent },
-          { path: 'settings', component: SettingsComponent },
+          { path: 'yVirtual', component: PreferencesComponent },
+          { path: 'preferences', component: PreferencesComponent },
           { path: 'apps', component: ApplicationsComponent },
           {
             path: 'apps/:id',
@@ -112,8 +112,8 @@ const appRoutes: Routes = [
             component: RoleDetailsComponent,
             data: { global: true }
           },
-          { path: '', redirectTo: 'settings', pathMatch: 'full' },
-          { path: '**', redirectTo: 'settings', pathMatch: 'full' }
+          { path: '', redirectTo: 'preferences', pathMatch: 'full' },
+          { path: '**', redirectTo: 'preferences', pathMatch: 'full' }
         ]
       },
       { path: '', pathMatch: 'full', redirectTo: 'namespaces/workspace' },

--- a/core/src/luigi-config/navigation/navigation-data-init.js
+++ b/core/src/luigi-config/navigation/navigation-data-init.js
@@ -55,9 +55,14 @@ export let navigation = {
     items: [
       {
         icon: 'settings',
-        label: 'Settings',
-        link: '/home/settings'
-      }
+        label: 'Preferences',
+        link: '/home/preferences'
+      },
+      {
+        icon: 'download',
+        label: 'Get Kubeconfig',
+        link: '/home/download-kubeconfig'
+      },
     ]
   },
   nodes: new Promise((res) => {

--- a/core/src/luigi-config/navigation/static-navigation-model.js
+++ b/core/src/luigi-config/navigation/static-navigation-model.js
@@ -1,7 +1,24 @@
 import { config } from '../config';
+import { getToken } from './navigation-helpers';
+import { saveAs } from 'file-saver';
 
 export const coreUIViewGroupName = '_core_ui_';
 export const consoleViewGroupName = '_console_';
+
+function downloadKubeconfig() {
+  const kubeconfigGeneratorUrl = `https://configurations-generator.${config.domain}/kube-config`;
+  const authHeader = { "Authorization": `Bearer ${getToken()}` };
+
+  fetch(kubeconfigGeneratorUrl, { headers: authHeader })
+    .then(res => res.blob())
+    .then(config => saveAs(config, 'kubeconfig.yml'))
+    .catch(err => {
+      alert('Cannot download kubeconfig.');
+      console.warn(err);
+    });
+
+  return false; // cancel Luigi navigation
+}
 
 export function getStaticChildrenNodesForNamespace(){
   return [
@@ -189,17 +206,23 @@ export function getStaticRootNodes(namespaceChildrenNodesResolver){
       hideFromNav: true
     },
     {
-      pathSegment: 'settings',
+      pathSegment: 'preferences',
       navigationContext: 'settings',
-      viewUrl: '/consoleapp.html#/home/settings/settings',
+      viewUrl: '/consoleapp.html#/home/settings/preferences',
       viewGroup: consoleViewGroupName,
-      hideFromNav: true
+      hideFromNav: true,
+    },
+    {
+      pathSegment: 'download-kubeconfig',
+      navigationContext: 'settings',
+      hideFromNav: true,
+      onNodeActivation: downloadKubeconfig,
     },
     {
       pathSegment: 'global-permissions',
       navigationContext: 'global-permissions',
       label: 'Global Permissions',
-      category: { label: 'Configuration', icon: 'settings' },
+      category: { label: 'Administration', icon: 'settings' },
       viewUrl: '/consoleapp.html#/home/settings/globalPermissions',
       keepSelectedForChildren: true,
       viewGroup: consoleViewGroupName,

--- a/core/src/luigi-config/navigation/static-navigation-model.js
+++ b/core/src/luigi-config/navigation/static-navigation-model.js
@@ -191,16 +191,15 @@ export function getStaticRootNodes(namespaceChildrenNodesResolver){
     {
       pathSegment: 'settings',
       navigationContext: 'settings',
-      label: 'General Settings',
-      category: { label: 'Settings', icon: 'settings' },
-      viewUrl: '/consoleapp.html#/home/settings/organisation',
-      viewGroup: consoleViewGroupName
+      viewUrl: '/consoleapp.html#/home/settings/settings',
+      viewGroup: consoleViewGroupName,
+      hideFromNav: true
     },
     {
       pathSegment: 'global-permissions',
       navigationContext: 'global-permissions',
       label: 'Global Permissions',
-      category: 'Settings',
+      category: { label: 'Configuration', icon: 'settings' },
       viewUrl: '/consoleapp.html#/home/settings/globalPermissions',
       keepSelectedForChildren: true,
       viewGroup: consoleViewGroupName,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Rename "Settings" category to "Administration"
- Move "Settings" view to top-right dropdown
- Remove organisation panel
- Move "Download Kubeconfig" to top-right dropdown
- Rename "Settings" view to "Preferences"

**Room for improvement?**
- I've decided to go for "Get Kubeconfig" instead of "Download Kubeconfig", as the former is shorter and it looks a bit more pleasurably IMHO.
- I've choosen generic `download` icon for Kubeconfig, but we can also choose famous ~marshmallow~ [`connect`](https://sapui5.hana.ondemand.com/test-resources/sap/m/demokit/iconExplorer/webapp/index.html#/overview/SAP-icons/?tab=grid&icon=connected&search=connect) icon.

**Related issue(s)**
#1073 
