### PR TITLE
Update serverless domain to use envs from configmap

### DIFF
--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/EditVariablesForm.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/EditVariablesForm.js
@@ -58,7 +58,11 @@ export default function EditVariablesForm({
   };
 
   const [variables, setVariables] = useState(
-    validateVariables(customVariables, injectedVariables),
+    validateVariables(
+      customVariables,
+      injectedVariables,
+      getReservedEnvs(configMapWebhookDefaults),
+    ),
   );
 
   useEffect(() => {
@@ -99,7 +103,11 @@ export default function EditVariablesForm({
       }
       return oldVariable;
     });
-    newVariables = validateVariables(newVariables, injectedVariables);
+    newVariables = validateVariables(
+      newVariables,
+      injectedVariables,
+      getReservedEnvs(configMapWebhookDefaults),
+    );
     setVariables(newVariables);
   }
 
@@ -107,7 +115,11 @@ export default function EditVariablesForm({
     let newVariables = variables.filter(
       oldVariable => oldVariable.id !== variable.id,
     );
-    newVariables = validateVariables(newVariables, injectedVariables);
+    newVariables = validateVariables(
+      newVariables,
+      injectedVariables,
+      getReservedEnvs(configMapWebhookDefaults),
+    );
     setVariables(newVariables);
   }
 

--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/EditVariablesForm.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/EditVariablesForm.js
@@ -44,13 +44,14 @@ export default function EditVariablesForm({
       name: WEBHOOK_DEFAULTS_CM_NAME,
       namespace: KYMA_SYSTEM_NAMESPACE,
     },
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: 'network-only',
   });
 
   const getReservedEnvs = configMap => {
     if (configMap.loading) {
       return CONFIG.restrictedVariables;
     }
+
     return configMap.data.configMap?.json.data.WEBHOOK_VALIDATION_RESERVED_ENVS.split(
       ',',
     );
@@ -139,7 +140,7 @@ export default function EditVariablesForm({
       setValidity,
       setCustomValid,
       setInvalidModalPopupMessage,
-      restricedVariables: getReservedEnvs(configMapWebhookDefaults),
+      restrictedVariables: getReservedEnvs(configMapWebhookDefaults),
     });
 
   function addNewVariable() {

--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/SingleVariableInput.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/SingleVariableInput.js
@@ -4,7 +4,6 @@ import { FormItem, FormInput, FormMessage } from 'fundamental-react';
 
 import { VARIABLE_VALIDATION } from 'components/Lambdas/helpers/lambdaVariables';
 import { ENVIRONMENT_VARIABLES_PANEL } from 'components/Lambdas/constants';
-import { CONFIG } from 'components/Lambdas/config';
 
 import { getValidationStatus, validateVariable } from './validation';
 
@@ -15,6 +14,7 @@ export default function SingleVariableInput({
   onUpdateVariables,
   setValidity,
   setInvalidModalPopupMessage,
+  restrictedVariables,
 }) {
   const [variable, setVariable] = useState(currentVariable);
   const [debouncedCallback] = useDebouncedCallback(newVariable => {
@@ -52,7 +52,7 @@ export default function SingleVariableInput({
     const validation = getValidationStatus({
       userVariables: variables,
       injectedVariables,
-      restrictedVariables: CONFIG.restrictedVariables,
+      restrictedVariables: restrictedVariables,
       varName: name,
       varID: variable.id,
       varDirty: variable.dirty,

--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/test/LambdaVariables.test.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/test/LambdaVariables.test.js
@@ -1,7 +1,15 @@
 import React from 'react';
-import { render, fireEvent, wait } from '@testing-library/react';
+import { render, fireEvent, wait, act } from '@testing-library/react';
+import {
+  WEBHOOK_DEFAULTS_CM_NAME,
+  KYMA_SYSTEM_NAMESPACE,
+} from 'components/Lambdas/constants';
+import {
+  lambdaMock,
+  withApolloMockProvider,
+} from 'components/Lambdas/helpers/testing';
+import { GET_CONFIGMAP_DATA_MOCK } from 'components/Lambdas/gql/hooks/queries/testMocks/useLambdasQuery';
 
-import { lambdaMock } from 'components/Lambdas/helpers/testing';
 import {
   newVariableModel,
   VARIABLE_VALIDATION,
@@ -10,7 +18,6 @@ import {
 import { ENVIRONMENT_VARIABLES_PANEL } from 'components/Lambdas/constants';
 
 import LambdaVariables from '../LambdaVariables';
-import { formatMessage } from 'components/Lambdas/helpers/misc';
 
 const timeout = 10000;
 
@@ -54,16 +61,26 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
     }),
   ];
 
+  const configMapMock = GET_CONFIGMAP_DATA_MOCK({
+    name: WEBHOOK_DEFAULTS_CM_NAME,
+    namespace: KYMA_SYSTEM_NAMESPACE,
+  });
+
   it(
     'Render with minimal props',
     async () => {
       const { getByText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={[]}
-          customValueFromVariables={[]}
-          injectedVariables={[]}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={[]}
+              customValueFromVariables={[]}
+              injectedVariables={[]}
+            />
+          ),
+        }),
       );
 
       expect(
@@ -80,13 +97,20 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
   it(
     'should render table with some data',
     async () => {
+      GET_CONFIGMAP_DATA_MOCK;
+
       const { container, queryByRole, queryAllByRole, getAllByText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={customVariables}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={customVariables}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const table = queryByRole('table');
@@ -116,12 +140,17 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
     'should show modal after click action button',
     async () => {
       const { getByText, getByRole } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={[]}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={[]}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const button = getByText(
@@ -134,15 +163,20 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
   );
 
   it(
-    'should not able to save variables if there are any custom variables',
+    'should not be able to save variables if there are any custom variables',
     async () => {
       const { getByText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={[]}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={[]}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const button = getByText(
@@ -163,12 +197,17 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
     'should can save variables when custom variables override injected variables',
     async () => {
       const { getByText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={customVariables}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={customVariables}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const button = getByText(
@@ -189,12 +228,17 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
     'should show warnings about override injected variables in edit form',
     async () => {
       const { getByText, getAllByText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={customVariables}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={customVariables}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const button = getByText(
@@ -215,12 +259,17 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
     'should can save if user delete all custom variables - case when custom variables exist',
     async () => {
       const { getByText, getAllByLabelText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={customVariables}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={customVariables}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const button = getByText(
@@ -247,12 +296,17 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
     'should not able to save when user types duplicated names',
     async () => {
       const { getByText, getAllByPlaceholderText, getAllByText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={customVariables}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={customVariables}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const button = getByText(
@@ -283,12 +337,17 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
     'should not able to save when user types restricted names',
     async () => {
       const { getByText, getAllByPlaceholderText, getAllByText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={customVariables}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={customVariables}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const button = getByText(
@@ -300,8 +359,10 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
         ENVIRONMENT_VARIABLES_PANEL.PLACEHOLDERS.VARIABLE_NAME,
       );
       expect(inputs).toHaveLength(2);
+      act(() => {
+        fireEvent.change(inputs[0], { target: { value: 'FUNC_PORT' } });
+      });
 
-      fireEvent.change(inputs[0], { target: { value: 'PORT' } });
       expect(
         getAllByText(ENVIRONMENT_VARIABLES_PANEL.ERRORS.RESTRICTED),
       ).toHaveLength(1);
@@ -319,12 +380,17 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
     'should not able to save when user types empty names - case with existing variable',
     async () => {
       const { getByText, getAllByPlaceholderText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={customVariables}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={customVariables}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const button = getByText(
@@ -352,12 +418,17 @@ describe('LambdaVariables + EditVariablesModal + EditVariablesForm', () => {
     'should not able to save when user add new variables - without empty error message',
     async () => {
       const { getByText } = render(
-        <LambdaVariables
-          lambda={lambdaMock}
-          customVariables={customVariables}
-          customValueFromVariables={[]}
-          injectedVariables={injectedVariables}
-        />,
+        withApolloMockProvider({
+          mocks: [configMapMock],
+          component: (
+            <LambdaVariables
+              lambda={lambdaMock}
+              customVariables={customVariables}
+              customValueFromVariables={[]}
+              injectedVariables={injectedVariables}
+            />
+          ),
+        }),
       );
 
       const button = getByText(

--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/validation.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/validation.js
@@ -3,7 +3,6 @@ import {
   VARIABLE_VALIDATION,
   ERROR_VARIABLE_VALIDATION,
 } from 'components/Lambdas/helpers/lambdaVariables';
-import { CONFIG } from 'components/Lambdas/config';
 
 export function validateVariables(
   customVariables = [],

--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/validation.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Code/LambdaVariables/validation.js
@@ -8,12 +8,13 @@ import { CONFIG } from 'components/Lambdas/config';
 export function validateVariables(
   customVariables = [],
   injectedVariables = [],
+  restrictedVariables = [],
 ) {
   return customVariables.map((variable, _, array) => {
     const validation = getValidationStatus({
       userVariables: array,
       injectedVariables,
-      restrictedVariables: CONFIG.restrictedVariables,
+      restrictedVariables: restrictedVariables,
       varName: variable.name,
       varID: variable.id,
       varDirty: variable.dirty,

--- a/core-ui/src/components/Lambdas/config.js
+++ b/core-ui/src/components/Lambdas/config.js
@@ -23,7 +23,6 @@ const defaultConfig = {
     'FUNC_HANDLER',
     'FUNC_TIMEOUT',
     'FUNC_PORT',
-    'PORT',
     'MOD_NAME',
     'NODE_PATH',
     'REQ_MB_LIMIT',

--- a/core-ui/src/components/Lambdas/constants.js
+++ b/core-ui/src/components/Lambdas/constants.js
@@ -431,3 +431,6 @@ export const FUNCTION_CUSTOM_RESOURCE = {
   KIND: 'Function',
   API_VERSION: 'serverless.kyma-project.io/v1alpha1',
 };
+
+export const WEBHOOK_DEFAULTS_CM_NAME = 'serverless-webhook-envs';
+export const KYMA_SYSTEM_NAMESPACE = 'kyma-system';

--- a/core-ui/src/components/Lambdas/gql/hooks/queries/testMocks/useLambdasQuery.js
+++ b/core-ui/src/components/Lambdas/gql/hooks/queries/testMocks/useLambdasQuery.js
@@ -1,6 +1,10 @@
-import { GET_LAMBDAS } from 'components/Lambdas/gql/queries';
+import { GET_LAMBDAS, GET_CONFIGMAP } from 'components/Lambdas/gql/queries';
 import { LAMBDA_EVENT_SUBSCRIPTION } from 'components/Lambdas/gql/subscriptions';
-import { TESTING_STATE, lambdaMock } from 'components/Lambdas/helpers/testing';
+import {
+  TESTING_STATE,
+  lambdaMock,
+  configMapMock,
+} from 'components/Lambdas/helpers/testing';
 
 export const GET_LAMBDAS_ERROR_MOCK = variables => ({
   request: {
@@ -18,6 +22,18 @@ export const GET_LAMBDAS_DATA_MOCK = (variables, functions = [lambdaMock]) => ({
   result: {
     data: {
       functions,
+    },
+  },
+});
+
+export const GET_CONFIGMAP_DATA_MOCK = variables => ({
+  request: {
+    query: GET_CONFIGMAP,
+    variables,
+  },
+  result: {
+    data: {
+      configMapMock,
     },
   },
 });

--- a/core-ui/src/components/Lambdas/gql/queries.js
+++ b/core-ui/src/components/Lambdas/gql/queries.js
@@ -1,5 +1,13 @@
 import gql from 'graphql-tag';
 
+export const GET_CONFIGMAP = gql`
+  query configMap($name: String!, $namespace: String!) {
+    configMap(name: $name, namespace: $namespace) {
+      json
+    }
+  }
+`;
+
 export const GET_LAMBDAS = gql`
   query functions($namespace: String!) {
     functions(namespace: $namespace) {

--- a/core-ui/src/components/Lambdas/helpers/testing/mockData.js
+++ b/core-ui/src/components/Lambdas/helpers/testing/mockData.js
@@ -119,3 +119,14 @@ export const serviceInstanceMock = {
     ],
   },
 };
+
+export const configMapMock = {
+  confgMap: {
+    json: {
+      data: {
+        WEBHOOK_VALIDATION_RESERVED_ENVS:
+          'FUNC_RUNTIME, FUNC_HANDLER, FUNC_TIMEOUT, FUNC_PORT, MOD_NAME, NODE_PATH, REQ_MB_LIMIT, FUNC_MEMORY_LIMIT',
+      },
+    },
+  },
+};


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request: unhardcode restriced envs and read them from configmap

- Update serverless domain to use envs from configmap
- we are not reading min resources from configmap _yet_, as it would mean we would need to change a lot of files (basically we read them in normal js functions, not inside any component, so we can't use `useQuery` hook, and we do not export apollo-client instance :sad:)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/8780