### PR TITLE
Fix logs view not hiding

### DIFF
--- a/core-ui/src/components/Lambdas/helpers/misc/useLogsView.js
+++ b/core-ui/src/components/Lambdas/helpers/misc/useLogsView.js
@@ -33,7 +33,12 @@ export const useLogsView = (uid, namespace, initialCollapse = true) => {
       logsViewHandle = openLogsView(linkManager, initialCollapse);
     }
 
-    const cleanup = () => logsViewHandle && logsViewHandle.close();
+    const cleanup = () => {
+      // workaround for destroy splitView with navigation from details to list view
+      // close doesn't work with collapsed state, so first expand and then close
+      logsViewHandle && logsViewHandle.expand();
+      logsViewHandle && logsViewHandle.close();
+    };
 
     // when user switches to another MF, useEffects's cleanup
     // function may not be fired - detect it manually


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bring back workaround for hiding logs view. It turns out it was useful after all.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
