### PR TITLE
Fix double fetch on Instances

### DIFF
--- a/service-catalog-ui/src/builder.js
+++ b/service-catalog-ui/src/builder.js
@@ -8,9 +8,10 @@ class Builder {
   backendModules = [];
 
   addEventListeners(callback) {
-    LuigiClient.addInitListener(e => {
+    const eventId = LuigiClient.addInitListener(e => {
       this.setCurrentContext(e);
       callback();
+      LuigiClient.removeInitListener(eventId);
     });
 
     LuigiClient.addContextUpdateListener(e => {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

App re-render `callback` was called twice, by Luigi's context init listener, even though function subscribing (`Builder::addEventListeners`) was definitely called only once. It caused the entire UI to re-render, refetching used queries.

I made sure to unsubscribe init listener after a call.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
