### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,17 +4,17 @@
 /catalog/ @akucharska @dariadomagala @parostatkiem @kwiatekus @Wawrzyn321
 /instances/ @akucharska @dariadomagala @parostatkiem @kwiatekus @Wawrzyn321
 /brokers/ @akucharska @dariadomagala @parostatkiem @kwiatekus @Wawrzyn321
-/content/ @michal-hudy @aerfio @m00g3n @magicmatatjahu @pPrecel
+/content/ @aerfio @m00g3n @magicmatatjahu @pPrecel
 /compass/ @dariadomagala @akucharska @parostatkiem @kwiatekus @Wawrzyn321
 /components/angular/ @dariadomagala @akucharska @parostatkiem @kwiatekus @Wawrzyn321
-/components/react/ @michal-hudy @aerfio @m00g3n @magicmatatjahu @pPrecel @akucharska @dariadomagala @parostatkiem @kwiatekus @Wawrzyn321
+/components/react/ @aerfio @m00g3n @magicmatatjahu @pPrecel @akucharska @dariadomagala @parostatkiem @kwiatekus @Wawrzyn321
 /core/ @dariadomagala @parostatkiem @akucharska @kwiatekus @Wawrzyn321
 /tests/ @akucharska @dariadomagala @parostatkiem @kwiatekus @Wawrzyn321
-/core-ui/src/components/Lambdas/ @michal-hudy @aerfio @m00g3n @pPrecel @magicmatatjahu
+/core-ui/src/components/Lambdas/ @aerfio @m00g3n @pPrecel @magicmatatjahu
 
 # Owners of all .md files in the repository
-*.md @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
-/core-ui/src/components/Lambdas/constants.js @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
+*.md @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
+/core-ui/src/components/Lambdas/constants.js @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
 
 # Owners of config file for MILV - milv.config.yaml
-milv.config.yaml @michal-hudy @aerfio @m00g3n @magicmatatjahu @pPrecel
+milv.config.yaml @aerfio @m00g3n @magicmatatjahu @pPrecel

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,7 +18,6 @@ aliases:
     documentation-reviewers:
     - kazydek
     - klaudiagrz
-    - tomekpapiernik
     - bszwarc
     - mmitoraj
     - majakurcius
@@ -26,7 +25,6 @@ aliases:
     documentation-approvers:
     - kazydek
     - klaudiagrz
-    - tomekpapiernik
     - bszwarc
     - mmitoraj
     - majakurcius


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In recent months, Paweł Kosiec, Adam Szecówka, Tomek Papiernik and Michał Hudy left the company. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. As for the persons mentioned above, the following reasons occurred:

- After consulting Paweł and Tomek, I've learned that they are no longer interested in contributing to the project.
- Adam has been inactive for more than 3 months.
- Michał has changed his GitHub login and thus the old one should be removed from all the codeowners files. His new login is already mentioned in the [emeritus file](https://github.com/kyma-project/community/blob/master/emeritus.md).

Changes proposed in this pull request:

- Remove `pkosiec` from codeowners
- Remove `aszecowka` from codeowners
- Remove `tomekpapiernik` from codeowners
- Remove `michal-hudy` from codeowners

**Related issue(s)**
[#50](https://github.tools.sap/kyma/community/issues/50)