### PR TITLE
Fix documentation not being stretched

### DIFF
--- a/components/generic-documentation/src/layouts/ContentUI.tsx
+++ b/components/generic-documentation/src/layouts/ContentUI.tsx
@@ -12,7 +12,7 @@ export interface ContentUILayoutProps {
 export const ContentUILayout: React.FunctionComponent<ContentUILayoutProps> = ({
   renderers,
 }) => (
-  <Grid.Container className="grid-container">
+  <Grid.Container width="auto" padding="0" className="grid-container">
     <StickyContainer>
       <Grid.Row>
         <Grid.Unit df={9} sm={12} className="grid-unit-content">

--- a/components/generic-documentation/src/layouts/styled.ts
+++ b/components/generic-documentation/src/layouts/styled.ts
@@ -4,11 +4,6 @@ import { tabsStyling } from '../renderers/styled';
 export const ContentUIWrapper = styled.div`
   &&& {
     width: 100%;
-
-    .grid-container {
-      margin-left: 295px;
-      padding: 15px;
-    }
   }
 `;
 
@@ -43,11 +38,6 @@ export const CatalogUIWrapper = styled.div`
 
     .grid-unit-content > div {
       border: none;
-      margin: 0;
-    }
-
-    .grid-container {
-      padding: 0;
       margin: 0;
     }
 
@@ -101,11 +91,6 @@ export const InstancesUIWrapper = styled.div`
       > section {
         padding: 16px;
       }
-    }
-
-    .grid-container {
-      padding: 0;
-      margin: 0;
     }
 
     .grid-unit-content > div {

--- a/components/generic-documentation/src/renderers/Group.renderer.tsx
+++ b/components/generic-documentation/src/renderers/Group.renderer.tsx
@@ -135,7 +135,7 @@ export const GroupRenderer: React.FunctionComponent<GroupRendererProps> = ({
       {markdownsExists && (
         <Tab label={TabsLabels.DOCUMENTATION} id={TabsLabels.DOCUMENTATION}>
           <MarkdownWrapper className="custom-markdown-styling">
-            <Grid.Container className="grid-container">
+            <Grid.Container width="auto" className="grid-container">
               <StickyContainer>
                 <Grid.Row>
                   <Grid.Unit df={9} sm={12} className="grid-unit-content">

--- a/components/shared/src/Grid/index.ts
+++ b/components/shared/src/Grid/index.ts
@@ -50,7 +50,7 @@ interface GridContainerProps {
 const GridContainer = styled.div<GridContainerProps>`
   width: ${props => (props.width ? props.width : '1200px')};
   max-width: 100%;
-  ${props => (props.padding ? props.padding : 'padding: 30px 30px 0 30px')};
+  ${props => (props.padding ? props.padding : 'padding: 1em 1em 0 1em')};
   margin: 0 auto;
 `;
 

--- a/content/src/core/App.tsx
+++ b/content/src/core/App.tsx
@@ -22,10 +22,10 @@ export const App: React.FunctionComponent = () => {
 
   return (
     <Wrapper>
-      <Grid.Container className="grid-container" width="auto">
+      <Grid.Container className="grid-container" padding="0" width="auto">
         <StickyContainer>
-          <Grid.Row>
-            <Grid.Unit df={3} sm={0}>
+          <Grid.Row style={{ margin: 0 }}>
+            <Grid.Unit style={{ padding: 0 }} df={3} sm={0}>
               <Sticky>
                 {({ style }: any) => (
                   <div style={{ ...style, zIndex: 200 }}>

--- a/content/src/core/App.tsx
+++ b/content/src/core/App.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
-import { Router } from '@reach/router'
-import { StickyContainer, Sticky } from "react-sticky";
+import { Router } from '@reach/router';
+import { StickyContainer, Sticky } from 'react-sticky';
 import { Grid, Spinner } from '@kyma-project/components';
 
 import { Content } from '../components/Content';
@@ -21,28 +21,28 @@ export const App: React.FunctionComponent = () => {
   }
 
   return (
-      <Wrapper>
-        <Grid.Container className="grid-container" width="1370px">
-          <StickyContainer>
-            <Grid.Row>
-              <Grid.Unit df={3} sm={0}>
-                <Sticky>
-                  {({ style }: any) => (
-                    <div style={{ ...style, zIndex: 200 }}>
-                      <Navigation />
-                    </div>
-                  )}
-                </Sticky>
-              </Grid.Unit>
-              <Grid.Unit df={9} sm={12}>
-                <Router>
-                  <Content path="/" />
-                  <Content path="/:group/:topic" />
-                </Router>
-              </Grid.Unit>
-            </Grid.Row>
-          </StickyContainer>
-        </Grid.Container>
-      </Wrapper>
+    <Wrapper>
+      <Grid.Container className="grid-container" width="auto">
+        <StickyContainer>
+          <Grid.Row>
+            <Grid.Unit df={3} sm={0}>
+              <Sticky>
+                {({ style }: any) => (
+                  <div style={{ ...style, zIndex: 200 }}>
+                    <Navigation />
+                  </div>
+                )}
+              </Sticky>
+            </Grid.Unit>
+            <Grid.Unit df={9} sm={12}>
+              <Router>
+                <Content path="/" />
+                <Content path="/:group/:topic" />
+              </Router>
+            </Grid.Unit>
+          </Grid.Row>
+        </StickyContainer>
+      </Grid.Container>
+    </Wrapper>
   );
 };

--- a/content/src/core/styled.ts
+++ b/content/src/core/styled.ts
@@ -1,13 +1,6 @@
 import styled from 'styled-components';
 
-export const Wrapper = styled.div`
-  &&& {
-    .grid-container {
-      margin: 0;
-      padding: 0;
-    }
-  }
-`;
+export const Wrapper = styled.div``;
 
 export const ErrorWrapper = styled.div`
   padding: 16px;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- remove some random css rules for `.grid-container`
- adjust default padding for `Grid.Container` to 1em
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
