### PR TITLE
Fix create credentials w/o any parameters required

### DIFF
--- a/service-catalog-ui/src/components/ServiceInstanceDetails/ServiceInstanceBindings/CreateCredentialsModal/CreateCredentialsModal.component.js
+++ b/service-catalog-ui/src/components/ServiceInstanceDetails/ServiceInstanceBindings/CreateCredentialsModal/CreateCredentialsModal.component.js
@@ -9,6 +9,7 @@ import { bindingVariables } from '../InfoButton/variables';
 
 import { clearEmptyPropertiesInObject } from 'helpers';
 import LuigiClient from '@luigi-project/client';
+import * as _ from 'lodash';
 
 import WithNotificationContext from '../WithNotificationContext/WithNotificationContext';
 
@@ -119,7 +120,10 @@ class CreateCredentialsModal extends React.Component {
   };
   createWithoutOpening = () => {
     const { bindingCreateParameterSchema } = this.state;
-    if (!bindingCreateParameterSchema) {
+    if (
+      !bindingCreateParameterSchema ||
+      _.isEmpty(bindingCreateParameterSchema)
+    ) {
       this.create();
     }
   };


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- trigger credentials creation in service catalog UI also in case when bindingParametersSchema arrives as empty object

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
