### PR TITLE
Fix ServicesDropdown bug

### DIFF
--- a/core-ui/src/components/ApiRules/ApiRuleForm/ServicesDropdown/ServicesDropdown.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/ServicesDropdown/ServicesDropdown.js
@@ -24,12 +24,9 @@ const ServicesDropdown = ({
     ? `${defaultValue.name}:${defaultValue.port}`
     : null;
 
-  const getServices = () => {
-    if (serviceName) {
-      return data.services.filter(s => s.name === serviceName);
-    }
-    return data.services;
-  };
+  const services = serviceName
+    ? data.services.filter(s => s.name === serviceName)
+    : data.services;
 
   return (
     <FormItem>
@@ -38,18 +35,23 @@ const ServicesDropdown = ({
         ref={_ref}
         id="service"
         role="select"
+        required
         defaultValue={defaultService}
       >
-        {getServices().map(service =>
-          service.ports.map(port => (
-            <option
-              aria-label="option"
-              key={service.name + port.port}
-              value={`${service.name}:${port.port}`}
-            >
-              {service.name} (port: {port.port})
-            </option>
-          )),
+        {services.length ? (
+          services.map(service =>
+            service.ports.map(port => (
+              <option
+                aria-label="option"
+                key={service.name + port.port}
+                value={`${service.name}:${port.port}`}
+              >
+                {service.name} (port: {port.port})
+              </option>
+            )),
+          )
+        ) : (
+          <option disabled>No services in this namespace</option>
         )}
       </FormSelect>
     </FormItem>

--- a/core-ui/src/components/ApiRules/ApiRuleForm/ServicesDropdown/test/ServicesDropdown.test.js
+++ b/core-ui/src/components/ApiRules/ApiRuleForm/ServicesDropdown/test/ServicesDropdown.test.js
@@ -68,4 +68,17 @@ describe('ServicesDropdown', () => {
     );
     expect(getAllByLabelText('option')).toMatchSnapshot();
   });
+
+  it('Show message if there are no services', async () => {
+    const { getByText } = render(
+      <ServicesDropdown
+        _ref={ref}
+        loading={false}
+        data={{
+          services: [],
+        }}
+      />,
+    );
+    expect(getByText('No services in this namespace')).toBeInTheDocument();
+  });
 });

--- a/core-ui/src/components/NamespaceList/NamespacesGrid/test/NamespaceGrid.test.js
+++ b/core-ui/src/components/NamespaceList/NamespacesGrid/test/NamespaceGrid.test.js
@@ -7,7 +7,7 @@ const sampleNamespaces = [
   {
     name: 'first-namespace',
     status: 'Active',
-    allPodsCount: 3,
+    podsCount: 3,
     healthyPodsCount: 2,
     isSystemNamespace: false,
     applications: 2,
@@ -15,7 +15,7 @@ const sampleNamespaces = [
   {
     name: 'second-namespace',
     status: 'Active',
-    allPodsCount: 4,
+    podsCount: 4,
     healthyPodsCount: 3,
     isSystemNamespace: true,
     applications: 3,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `required` attribute to APIRule service dropdown, so that form submit is disabled when no service is selected, resolving the bug.
- Add information to service dropdown when there are no services. I tried removing the checkmark, but [it may not be possible](https://stackoverflow.com/questions/11179904/remove-checkmark-in-webkit-select).
- Add test case for 0 services.
- Adjust test data in `NamespaceGrid` test (propTypes warning).

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
