### PR TITLE
Fix system namespaces switch

### DIFF
--- a/shared/hooks/test/useShowSystemNamespaces.test.js
+++ b/shared/hooks/test/useShowSystemNamespaces.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useShowSystemNamespaces } from '../useShowSystemNamespaces.js';
+
+let mockToggles = [];
+jest.mock('@luigi-project/client', () => ({
+  getActiveFeatureToggles: () => mockToggles,
+}));
+
+function TestComponent() {
+  const showSystemNamespaces = useShowSystemNamespaces();
+  return <p data-testid="value">{showSystemNamespaces.toString()}</p>;
+}
+
+describe('useShowSystemNamespaces', () => {
+  it('Changes returned value during re-renders', () => {
+    const { queryByTestId, rerender } = render(<TestComponent />);
+    expect(queryByTestId('value')).toHaveTextContent('false');
+
+    mockToggles = ['showSystemNamespaces'];
+
+    rerender(<TestComponent />);
+    expect(queryByTestId('value')).toHaveTextContent('true');
+
+    mockToggles = ['anotherFeature'];
+
+    rerender(<TestComponent />);
+    expect(queryByTestId('value')).toHaveTextContent('false');
+  });
+});

--- a/shared/hooks/useShowSystemNamespaces.js
+++ b/shared/hooks/useShowSystemNamespaces.js
@@ -1,12 +1,7 @@
 import LuigiClient from '@luigi-project/client';
-import { useMemo } from 'react';
 
 export function useShowSystemNamespaces() {
-  return useMemo(
-    () =>
-      (LuigiClient.getActiveFeatureToggles() || []).includes(
-        'showSystemNamespaces',
-      ),
-    [LuigiClient.getActiveFeatureToggles()],
+  return (LuigiClient.getActiveFeatureToggles() || []).includes(
+    'showSystemNamespaces',
   );
 }

--- a/shared/hooks/useShowSystemNamespaces.js
+++ b/shared/hooks/useShowSystemNamespaces.js
@@ -7,6 +7,6 @@ export function useShowSystemNamespaces() {
       (LuigiClient.getActiveFeatureToggles() || []).includes(
         'showSystemNamespaces',
       ),
-    [],
+    [LuigiClient.getActiveFeatureToggles()],
   );
 }


### PR DESCRIPTION
**Description**

To investigate the issue, I added a test - that failed, while it shouldn't.
Turns out, after re-entering a view after changing feature toggles, Luigi's `getActiveFeatureToggles` returns _undefined_ for a short period of time. `useSystemNamespaces` used `useMemo` with empty dependency array, effectively checking for features only once - hence invalid behaviour.

First solution ("_useMemo dependency solution_" commit) adds `Luigi.getActiveFeatureToggles()` to hook's dependency array. I decided to remove `useMemo` altogether, as function inside isn't computationally expensive, and `getActiveFeatureToggles` is needed every call anyway.

Of course, another problem arises - when we enable system namespaces and return to namespaces view, two GQL calls are performed - first, when toggles are _undefined_ (=> _false_) and second, when toggles are valid (=> _true_). It seems we can't bypass this issue while using toggles feature on Luigi (or an async hook, that would wait for the toggles array to be defined).

Changes proposed in this pull request:

- Add test for `useSystemNamespaces` hook
- Remove `useMemo` from the hook

**Related issue(s)**
[Original issue](https://github.com/kyma-project/kyma/issues/8268)
