### PR TITLE
Fix columns and nav name

### DIFF
--- a/core/src/app/content/namespaces/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
+++ b/core/src/app/content/namespaces/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
@@ -21,24 +21,21 @@
     <td>
       <ng-container
         *ngIf="
-          true
-        "
+        entry.boundServiceInstanceNames &&
+        entry.boundServiceInstanceNames.length > 0
+        ; else noBoundServiceInstances"
       >
-        <a class="fd-has--block"
+        <a class="fd-has-display-block"
           href="javascript:void(null)"
-          *ngFor="let instance of ['svc-a', 'svc-b', 's-c', 's-d']"
+          *ngFor="let instance of entry.boundServiceInstanceNames"
           (click)="goToServiceInstanceDetails(instance)"
         >
           {{ instance }}
         </a>
       </ng-container>
-      <ng-container
-        *ngIf="
-          false
-        "
-      >
+      <ng-template #noBoundServiceInstances>
         {{ emptyText }}
-      </ng-container>
+      </ng-template>
     </td>
   </ng-container>
   <td>

--- a/core/src/app/content/namespaces/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
+++ b/core/src/app/content/namespaces/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
@@ -13,7 +13,7 @@
   </td>
   <td>{{ entry.creationTimestamp * 1000 | timeAgo }}</td>
   <td>
-    <span *ngFor="let image of entry.containers">
+    <span *ngFor="let image of entry.containers" class="fd-has-display-block">
       {{ image.image }}
     </span>
   </td>
@@ -21,13 +21,12 @@
     <td>
       <ng-container
         *ngIf="
-          entry.boundServiceInstanceNames &&
-          entry.boundServiceInstanceNames.length > 0
+          true
         "
       >
-        <a
+        <a class="fd-has--block"
           href="javascript:void(null)"
-          *ngFor="let instance of entry.boundServiceInstanceNames"
+          *ngFor="let instance of ['svc-a', 'svc-b', 's-c', 's-d']"
           (click)="goToServiceInstanceDetails(instance)"
         >
           {{ instance }}
@@ -35,8 +34,7 @@
       </ng-container>
       <ng-container
         *ngIf="
-          !entry.boundServiceInstanceNames ||
-          entry.boundServiceInstanceNames.length === 0
+          false
         "
       >
         {{ emptyText }}

--- a/core/src/app/content/namespaces/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
+++ b/core/src/app/content/namespaces/operation/deployments/deployment-entry-renderer/deployment-entry-renderer.component.html
@@ -13,26 +13,27 @@
   </td>
   <td>{{ entry.creationTimestamp * 1000 | timeAgo }}</td>
   <td>
-    <span *ngFor="let image of entry.containers" class="fd-has-display-block">
-      {{ image.image }}
-    </span>
+    <ul class="table-list">
+      <li *ngFor="let image of entry.containers">
+        {{ image.image }}
+      </li>
+    </ul>
   </td>
   <ng-container *ngIf="showBoundServices">
     <td>
-      <ng-container
+      <ul
+        class="table-list"
         *ngIf="
         entry.boundServiceInstanceNames &&
         entry.boundServiceInstanceNames.length > 0
         ; else noBoundServiceInstances"
-      >
-        <a class="fd-has-display-block"
-          href="javascript:void(null)"
-          *ngFor="let instance of entry.boundServiceInstanceNames"
-          (click)="goToServiceInstanceDetails(instance)"
-        >
+      ><li>
+        <a class="fd-has-display-block" href="javascript:void(null)" *ngFor="let instance of entry.boundServiceInstanceNames"
+          (click)="goToServiceInstanceDetails(instance)">
           {{ instance }}
         </a>
-      </ng-container>
+      </li>
+      </ul>
       <ng-template #noBoundServiceInstances>
         {{ emptyText }}
       </ng-template>

--- a/core/src/app/content/namespaces/operation/replica-sets/replica-sets-entry-renderer/replica-sets-entry-renderer.component.html
+++ b/core/src/app/content/namespaces/operation/replica-sets/replica-sets-entry-renderer/replica-sets-entry-renderer.component.html
@@ -16,7 +16,7 @@
   <td>{{ entry.creationTimestamp * 1000 | timeAgo }}</td>
   <td>
     <ul class="table-list">
-      <li *ngFor="let image of entry.images" class="fd-has-display-block">
+      <li *ngFor="let image of entry.images">
         {{ image }}
       </li>
     </ul>

--- a/core/src/app/content/namespaces/operation/replica-sets/replica-sets-entry-renderer/replica-sets-entry-renderer.component.html
+++ b/core/src/app/content/namespaces/operation/replica-sets/replica-sets-entry-renderer/replica-sets-entry-renderer.component.html
@@ -15,9 +15,11 @@
   </td>
   <td>{{ entry.creationTimestamp * 1000 | timeAgo }}</td>
   <td>
-    <span *ngFor="let image of entry.images" class="fd-has-display-block">
-      {{ image }}
-    </span>
+    <ul class="table-list">
+      <li *ngFor="let image of entry.images" class="fd-has-display-block">
+        {{ image }}
+      </li>
+    </ul>
   </td>
   <td>
     <span

--- a/core/src/app/content/namespaces/operation/replica-sets/replica-sets-entry-renderer/replica-sets-entry-renderer.component.html
+++ b/core/src/app/content/namespaces/operation/replica-sets/replica-sets-entry-renderer/replica-sets-entry-renderer.component.html
@@ -15,7 +15,7 @@
   </td>
   <td>{{ entry.creationTimestamp * 1000 | timeAgo }}</td>
   <td>
-    <span *ngFor="let image of entry.images">
+    <span *ngFor="let image of entry.images" class="fd-has-display-block">
       {{ image }}
     </span>
   </td>

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -16,6 +16,9 @@
       .fd-nested-list__link .fd-nested-list__title {
         padding-right: 5px !important;
       }
+      :root {
+        --luigi__left-sidenav--width: 16rem;
+      }
     </style>
   </head>
 

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -13,6 +13,9 @@
       #app .fd-shellbar__title {
         display: none;
       }
+      .fd-nested-list__link .fd-nested-list__title {
+        padding-right: 5px !important;
+      }
     </style>
   </head>
 

--- a/core/src/styles.scss
+++ b/core/src/styles.scss
@@ -45,3 +45,11 @@ fd-icon.clickable {
     max-height: calc(100% - 7em);
   }
 }
+
+.table-list {
+  list-style: none;
+
+  & > :not(:last-child) {
+    margin-bottom: 4px;
+  }
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- 618: use `li` for enumerated service instances. I also fixed _images_ column in Deployments and Replice Sets views.
- 1975: add `padding-right` with `!important` to make sure the padding is actually here. More in issue description.

**Related issue(s)**
[#618](https://github.tools.sap/kyma/backlog/issues/618)
[#1975](https://github.com/kyma-project/console/issues/1975)
