### PR TITLE
Fix resource upload on Windows

### DIFF
--- a/core-ui/Dockerfile
+++ b/core-ui/Dockerfile
@@ -12,8 +12,7 @@ RUN apk update && \
 # Install root and app dependencies
 COPY . /app
 RUN cd /app/${app_name} && \
-  make resolve && \
-  make verify
+  make resolve
 
 
 # Set env variables

--- a/core-ui/Dockerfile
+++ b/core-ui/Dockerfile
@@ -12,7 +12,8 @@ RUN apk update && \
 # Install root and app dependencies
 COPY . /app
 RUN cd /app/${app_name} && \
-  make resolve
+  make resolve && \
+  make verify
 
 
 # Set env variables

--- a/core-ui/src/components/NamespaceDetails/DeployResourceModal/deployResourceHelpers.js
+++ b/core-ui/src/components/NamespaceDetails/DeployResourceModal/deployResourceHelpers.js
@@ -8,10 +8,9 @@ function validateFile(file) {
   if (!file.size) {
     return 'File cannot be empty';
   }
-  console.log(file);
-  console.log(file.type);
-  const allowedTypes = ['application/json', 'application/x-yaml'];
-  if (!allowedTypes.includes(file.type)) {
+
+  const allowedExtensionRegex = /\.(ya?ml|json)$/;
+  if (!allowedExtensionRegex.test(file.name)) {
     return 'Invalid file extension';
   }
   return '';

--- a/core-ui/src/components/NamespaceDetails/DeployResourceModal/deployResourceHelpers.js
+++ b/core-ui/src/components/NamespaceDetails/DeployResourceModal/deployResourceHelpers.js
@@ -8,7 +8,8 @@ function validateFile(file) {
   if (!file.size) {
     return 'File cannot be empty';
   }
-
+  console.log(file);
+  console.log(file.type);
   const allowedTypes = ['application/json', 'application/x-yaml'];
   if (!allowedTypes.includes(file.type)) {
     return 'Invalid file extension';

--- a/core-ui/src/components/NamespaceDetails/DeployResourceModal/deployResourceHelpers.js
+++ b/core-ui/src/components/NamespaceDetails/DeployResourceModal/deployResourceHelpers.js
@@ -8,8 +8,7 @@ function validateFile(file) {
   if (!file.size) {
     return 'File cannot be empty';
   }
-
-  const allowedExtensionRegex = /\.(ya?ml|json)$/;
+  const allowedExtensionRegex = /\.(ya?ml|json)$/i;
   if (!allowedExtensionRegex.test(file.name)) {
     return 'Invalid file extension';
   }

--- a/core-ui/src/components/NamespaceDetails/DeployResourceModal/test/deployResourceHelpers.test.js
+++ b/core-ui/src/components/NamespaceDetails/DeployResourceModal/test/deployResourceHelpers.test.js
@@ -27,7 +27,7 @@ describe('DeploResource helpers', () => {
     it('return error on invalid content type', async () => {
       const [content, error] = await parseFile({
         size: 1,
-        type: 'application/test',
+        name: 'test.jason',
       });
 
       expect(content).toBeNull();
@@ -39,7 +39,7 @@ describe('DeploResource helpers', () => {
 
       const [content, error] = await parseFile({
         size: 1,
-        type: 'application/json',
+        name: 'valid.json',
       });
 
       expect(content).toBe(null);
@@ -53,7 +53,7 @@ describe('DeploResource helpers', () => {
 
       const [content, error] = await parseFile({
         size: 1,
-        type: 'application/json',
+        name: 'valid.json',
       });
 
       expect(content).toEqual([true]);
@@ -65,7 +65,7 @@ describe('DeploResource helpers', () => {
 
       const [content, error] = await parseFile({
         size: 1,
-        type: 'application/json',
+        name: 'valid.json',
       });
 
       expect(content).toMatchObject({});
@@ -81,7 +81,7 @@ describe('DeploResource helpers', () => {
 
       const [content, error] = await parseFile({
         size: 1,
-        type: 'application/json',
+        name: 'valid.json',
       });
 
       expect(content).toMatchObject([{ a: 0 }]);
@@ -106,7 +106,7 @@ metadata: 6`;
 
       const [content, error] = await parseFile({
         size: 1,
-        type: 'application/json',
+        name: 'valid.json',
       });
 
       expect(content).toHaveLength(2);


### PR DESCRIPTION
**Description**

As it turns out, Windows doesn't set the `type` property on YAML files. As a workaround, I decided to verify the extension by checking the file extension itself.
Here is a screenshot from my Windows 10 - `file` and `file.type`.
![image](https://user-images.githubusercontent.com/10504661/96031793-1e1f1400-0e5e-11eb-9faf-79cc74ba50b1.png)

Changes proposed in this pull request:

- Check for _yaml_, _yml_ and _json extensions, instead of checking the file `type`.

**Related issue(s)**
[Original issue](https://github.com/kyma-project/console/issues/2023)