### PR TITLE
Add flags for cypress:test:cluster

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -2,7 +2,7 @@
   "name": "ui-tests",
   "description": "Smoke tests for Console",
   "scripts": {
-    "test:cluster": "$(npm bin)/cypress run --browser chrome --headless",
+    "test:cluster": "$(npm bin)/cypress run --quiet --browser chrome --headless --reporter junit --reporter-options mochaFile=artifacts/cypress-run.xml,toConsole=true",
     "start": "$(npm bin)/cypress open"
   },
   "devDependencies": {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove console output
- Add reporter options (temporarily with `toConsole` set to _true_)

**Related issue(s)**
[test-infra 2900](https://github.com/kyma-project/test-infra/issues/2900)
[Kyma](https://github.com/kyma-project/kyma/pull/9873)
