### PR TITLE
Fix doughnut charts 

### DIFF
--- a/core-ui/src/shared/components/CircleProgress/CircleProgress.js
+++ b/core-ui/src/shared/components/CircleProgress/CircleProgress.js
@@ -8,7 +8,7 @@ const CircleProgress = ({ value, max, color = 'blue', onClick, children }) => {
     'cursor-pointer': onClick,
   });
 
-  const percent = Math.round((value * 100) / max);
+  const percent = max ? Math.round((value * 100) / max) : 100;
   return (
     <div className="circle-progress" onClick={onClick}>
       <div className={circleClasses}>

--- a/core-ui/src/shared/components/CircleProgress/CircleProgress.js
+++ b/core-ui/src/shared/components/CircleProgress/CircleProgress.js
@@ -8,7 +8,7 @@ const CircleProgress = ({ value, max, color = 'blue', onClick, children }) => {
     'cursor-pointer': onClick,
   });
 
-  const percent = max ? Math.round((value * 100) / max) : 100;
+  const percent = max ? Math.round((value * 100) / max) : 0;
   return (
     <div className="circle-progress" onClick={onClick}>
       <div className={circleClasses}>

--- a/core-ui/src/shared/components/CircleProgress/CircleProgress.scss
+++ b/core-ui/src/shared/components/CircleProgress/CircleProgress.scss
@@ -57,7 +57,7 @@ $scale-compensation: 1.01; // enlarge masks a little bit to remove an unwanted "
         // it becomes the right half of the circle
         &.fill--#{$i} {
           background-color: $circle-color;
-          transform: rotate(calc((100 - #{$i} / 50) * 0.5turn + 0.5turn));
+          transform: rotate(calc((-#{$i} / 50 + 1) * 0.5turn));
         }
       }
     }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Set `percent` to 100 when resource count is 0 (before it resulted in NaN)
- Map rotation of right-half ring to <-1, 0> instead of <98,99>, so that current half doesn't jump when it crosses 1/2 threshold. 

**Related issue(s)**
Resolves #2008 
