### PR TITLE
Fix token expire logout

### DIFF
--- a/core/src/assets/static-views.js
+++ b/core/src/assets/static-views.js
@@ -12,10 +12,7 @@ function login() {
 }
 
 function getUrlParameter(name) {
-  name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
-  var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
-  var results = regex.exec(location.search);
-  return (results && decodeURIComponent(results[1].replace(/\+/g, ' '))) || '';
+  return new URL(location.href).searchParams.get(name);
 }
 
 var reason = getUrlParameter('reason');
@@ -27,6 +24,7 @@ if (error) {
 
 switch (reason) {
   case 'tokenExpired':
+    sessionStorage.removeItem('luigi.auth');
     document.getElementById('headline').innerText = 'Your session has expired.';
     break;
   case 'loginError':

--- a/core/src/nopermissions.html
+++ b/core/src/nopermissions.html
@@ -51,8 +51,8 @@
                 <span class="sap-icon--locked sap-icon--xl"></span>
                 <div class="info">Not enough permissions</div>
                 <div class="hint">
-                  <p class="fd-has-margin-tiny">You don't have enougth permissions to view this content.</p>
-                  <p class="fd-has-margin-tiny">Contact your administrator to grant you an access.</p>
+                  <p class="fd-has-margin-tiny">You don't have enough permissions to view this content.</p>
+                  <p class="fd-has-margin-tiny">Contact your administrator to grant you access.</p>
                 </div>
               </p>
               <p class="fd-has-text-align-center">


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove auth data when token expires. Without that, Console was loaded again on click on "Re-Login" button, which resulted in fetch with invalid token, thus "no permissions" redirect. Without token, it will navigate to the login page instead. 
- Use [somewhat leaner method](https://caniuse.com/?search=searchParams) of getting url params
- Fix typos mentioned in original issue

**Related issue(s)**
[Original issue](https://github.tools.sap/kyma/backlog/issues/838)