### PR TITLE
Fix Firefox instance binding in Functions

### DIFF
--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Configuration/ConfigurationTab.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Configuration/ConfigurationTab.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function ConfigurationTab({ children }) {
-  return <>{children}</>;
-}

--- a/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Configuration/ServiceBindings/CreateServiceBindingForm.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/Tabs/Configuration/ServiceBindings/CreateServiceBindingForm.js
@@ -90,7 +90,8 @@ export default function CreateServiceBindingForm({
     setExistingCredentials('');
   }, [serviceInstanceName, createCredentials]);
 
-  async function handleFormSubmit() {
+  async function handleFormSubmit(e) {
+    e.preventDefault();
     const parameters = {
       serviceInstanceName: serviceInstanceName,
       serviceBindingUsageParameters: envPrefix

--- a/core-ui/src/components/ModalWithForm/ModalWithForm.js
+++ b/core-ui/src/components/ModalWithForm/ModalWithForm.js
@@ -93,7 +93,7 @@ const ModalWithForm = ({
         ? form.reportValidity()
         : form.checkValidity()) // IE workaround; HTML validation tooltips won't be visible
     ) {
-      form.dispatchEvent(new Event('submit'));
+      form.dispatchEvent(new Event('submit', { cancelable: true }));
       setTimeout(() => setOpenStatus(false));
     }
   }
@@ -135,6 +135,7 @@ const ModalWithForm = ({
           modalOpeningComponent
         ) : (
           <Button
+            type="button"
             glyph={button.glyph || null}
             option={button.option}
             compact={button.compact || false}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- It turns out, CSP had nothing to do with instance binding - in Firefox, the form was automatically submitted and the page was reloaded. `preventDefault` would do.
- Remove `ConfigurationTab` file, as it wasn't used anywhere.

**Related issue(s)**
[Original issue](https://github.com/kyma-project/console/issues/2048)
[Bump](https://github.com/kyma-project/kyma/pull/9983)
