### PR TITLE
Update Console documentation CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@
 /core-ui/src/components/Lambdas/ @aerfio @m00g3n @pPrecel @magicmatatjahu
 
 # Owners of all .md files in the repository
-*.md @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
+*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla
 /core-ui/src/components/Lambdas/constants.js @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
 
 # Owners of config file for MILV - milv.config.yaml


### PR DESCRIPTION
**Description**

Since Barbara Sz. (@bszwarc) left us in September and is no longer an active contributor, she should be removed from CODEOWNERS.  
At the same time, Justyna Sz. (@superojla) joined us in September and has been contributing to Kyma documentation, so it's time to add her to CODEOWNERS. 

Changes proposed in this pull request:

- Remove @bszwarc from documentation CODEOWNERS
- Add @superojla to documentation CODEOWNERS
