### PR TITLE
Disable caching for get function gql query

### DIFF
--- a/core-ui/src/components/Lambdas/LambdaDetails/test/LambdaDetailsWrapper.test.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/test/LambdaDetailsWrapper.test.js
@@ -36,7 +36,7 @@ describe('LambdaDetailsWrapper', () => {
     const { getByLabelText } = render(
       withApolloMockProvider({
         component: <LambdaDetailsWrapper lambdaName={lambdaMock.name} />,
-        mocks: [subscriptionMock],
+        mocks: [subscriptionMock, subscriptionMock],
       }),
     );
 

--- a/core-ui/src/components/Lambdas/gql/hooks/queries/test/useLambdaQuery.test.js
+++ b/core-ui/src/components/Lambdas/gql/hooks/queries/test/useLambdaQuery.test.js
@@ -39,7 +39,7 @@ describe('useLambdaQuery', () => {
         component: (
           <QueryComponent hook={useLambdaQuery} hookInput={hookInput} />
         ),
-        mocks: [LAMBDA_EVENT_SUBSCRIPTION_MOCK(subscriptionVariable)],
+        mocks: [subscriptionMock, subscriptionMock],
       }),
     );
 

--- a/core-ui/src/components/Lambdas/gql/hooks/queries/useLambdaQuery.js
+++ b/core-ui/src/components/Lambdas/gql/hooks/queries/useLambdaQuery.js
@@ -22,7 +22,7 @@ export const useLambdaQuery = ({ name, namespace }) => {
 
   const { data, error, loading } = useQuery(GET_LAMBDA, {
     variables,
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'no-cache',
   });
 
   useEffect(() => {
@@ -43,6 +43,7 @@ export const useLambdaQuery = ({ name, namespace }) => {
   useEffect(() => {
     const observer = apolloClient.subscribe({
       query: LAMBDA_EVENT_SUBSCRIPTION,
+      fetchPolicy: 'no-cache',
       variables: {
         namespace,
         functionName: name,

--- a/core-ui/src/components/Lambdas/gql/hooks/queries/useLambdasQuery.js
+++ b/core-ui/src/components/Lambdas/gql/hooks/queries/useLambdasQuery.js
@@ -58,6 +58,7 @@ export const useLambdasQuery = ({ namespace }) => {
   useEffect(() => {
     const observer = apolloClient.subscribe({
       query: LAMBDA_EVENT_SUBSCRIPTION,
+      fetchPolicy: 'no-cache',
       variables,
     });
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Disable caching for get function gql query because current cache configuration requires object `name` field to be unique

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/kyma/issues/10303