### PR TITLE
Remove node10 from supported runtimes

### DIFF
--- a/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsHeader/LambdaDetailsHeader.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsHeader/LambdaDetailsHeader.js
@@ -58,7 +58,7 @@ export default function LambdaDetailsHeader({ lambda }) {
         <PageHeader.Column title={LAMBDA_DETAILS.RUNTIME.TEXT}>
           {prettyRuntime(lambda.runtime)}
           {lambda.runtime === 'nodejs10' && (
-            <InlineHelp placement="bottom-right" text="Upgrade to runtime Node.js 12 or newer to reconcile the Function" />
+            <InlineHelp placement="bottom-right" text="Use kubectl to upgrade Function's runtime to Node.js 12 or newer to reconcile the Function" />
           )}
         </PageHeader.Column>
         {isGitSourceType(lambda.sourceType) && (

--- a/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsHeader/LambdaDetailsHeader.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsHeader/LambdaDetailsHeader.js
@@ -58,7 +58,10 @@ export default function LambdaDetailsHeader({ lambda }) {
         <PageHeader.Column title={LAMBDA_DETAILS.RUNTIME.TEXT}>
           {prettyRuntime(lambda.runtime)}
           {lambda.runtime === 'nodejs10' && (
-            <InlineHelp placement="bottom-right" text="Use kubectl to upgrade Function's runtime to Node.js 12 or newer to reconcile the Function" />
+            <InlineHelp
+              placement="bottom-right"
+              text="Use kubectl to upgrade Function's runtime to Node.js 12 or newer to reconcile the Function"
+            />
           )}
         </PageHeader.Column>
         {isGitSourceType(lambda.sourceType) && (

--- a/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsHeader/LambdaDetailsHeader.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsHeader/LambdaDetailsHeader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button } from 'fundamental-react';
+import { Button, InlineHelp } from 'fundamental-react';
 import { PageHeader } from 'react-shared';
 
 import { useDeleteLambda } from 'components/Lambdas/gql/hooks/mutations';
@@ -57,6 +57,9 @@ export default function LambdaDetailsHeader({ lambda }) {
         </PageHeader.Column>
         <PageHeader.Column title={LAMBDA_DETAILS.RUNTIME.TEXT}>
           {prettyRuntime(lambda.runtime)}
+          {lambda.runtime === 'nodejs10' && (
+            <InlineHelp placement="bottom-right" text="Upgrade to runtime Node.js 12 or newer to reconcile the Function" />
+          )}
         </PageHeader.Column>
         {isGitSourceType(lambda.sourceType) && (
           <PageHeader.Column title={LAMBDA_DETAILS.REPOSITORY.TEXT}>

--- a/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsWrapper.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsWrapper.js
@@ -25,15 +25,14 @@ export default function LambdaDetailsWrapper({ lambdaName }) {
     content = <EntryNotFound entryType="Lambda" entryId={lambdaName} />;
   } else {
     const backendModules = LuigiClient.getEventData().backendModules;
-     if(lambda.runtime==='nodejs10'){
-       LuigiClient
-       .uxManager()
-       .showAlert({
-        text: "This Function runtime is no longer supported. Use kubectl to change runtime to nodejs12 or newer.",
+    if (lambda.runtime === 'nodejs10') {
+      LuigiClient.uxManager().showAlert({
+        text:
+          'This Function runtime is no longer supported. Use kubectl to change runtime to nodejs12 or newer.',
         type: 'warning',
-        closeAfter: 10000
-       });
-     }
+        closeAfter: 10000,
+      });
+    }
     content = <LambdaDetails lambda={lambda} backendModules={backendModules} />;
   }
 

--- a/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsWrapper.js
+++ b/core-ui/src/components/Lambdas/LambdaDetails/LambdaDetailsWrapper.js
@@ -25,6 +25,15 @@ export default function LambdaDetailsWrapper({ lambdaName }) {
     content = <EntryNotFound entryType="Lambda" entryId={lambdaName} />;
   } else {
     const backendModules = LuigiClient.getEventData().backendModules;
+     if(lambda.runtime==='nodejs10'){
+       LuigiClient
+       .uxManager()
+       .showAlert({
+        text: "This Function runtime is no longer supported. Use kubectl to change runtime to nodejs12 or newer.",
+        type: 'warning',
+        closeAfter: 10000
+       });
+     }
     content = <LambdaDetails lambda={lambda} backendModules={backendModules} />;
   }
 

--- a/core-ui/src/components/Lambdas/constants.js
+++ b/core-ui/src/components/Lambdas/constants.js
@@ -61,7 +61,6 @@ export const LAMBDA_PHASES = {
 };
 
 export const PRETTY_RUNTIME_NODEJS12_NAME = 'Node.js 12';
-export const PRETTY_RUNTIME_NODEJS10_NAME = 'Node.js 10 (Deprecated)';
 export const PRETTY_RUNTIME_PYTHON38_NAME = 'Python 3.8';
 
 export const LAMBDA_ERROR_PHASES = [

--- a/core-ui/src/components/Lambdas/helpers/runtime/runtime.js
+++ b/core-ui/src/components/Lambdas/helpers/runtime/runtime.js
@@ -17,12 +17,12 @@ export const functionAvailableLanguages = {
 };
 
 export const prettyRuntime = runtime => {
-  if (runtime === 'nodejs10'){
-    return 'Node.js 10 (Unsupported)'
+  if (runtime === 'nodejs10') {
+    return 'Node.js 10 (Unsupported)';
   } else {
-  return functionAvailableLanguages[runtime] || `Unknown: ${runtime}`;
+    return functionAvailableLanguages[runtime] || `Unknown: ${runtime}`;
   }
-}
+};
 
 export const runtimeToMonacoEditorLang = runtime => {
   switch (runtime) {

--- a/core-ui/src/components/Lambdas/helpers/runtime/runtime.js
+++ b/core-ui/src/components/Lambdas/helpers/runtime/runtime.js
@@ -2,7 +2,6 @@ import { CONFIG } from 'components/Lambdas/config';
 import { formatMessage } from 'components/Lambdas/helpers/misc';
 
 import {
-  PRETTY_RUNTIME_NODEJS10_NAME,
   PRETTY_RUNTIME_NODEJS12_NAME,
   PRETTY_RUNTIME_PYTHON38_NAME,
 } from '../../constants';
@@ -14,12 +13,16 @@ export const python38 = 'python38';
 export const functionAvailableLanguages = {
   // order of those keys is the same as order of available runtimes shown in Create Lambda Modal
   [nodejs12]: PRETTY_RUNTIME_NODEJS12_NAME,
-  [nodejs10]: PRETTY_RUNTIME_NODEJS10_NAME,
   [python38]: PRETTY_RUNTIME_PYTHON38_NAME,
 };
 
-export const prettyRuntime = runtime =>
-  functionAvailableLanguages[runtime] || `Unknown: ${runtime}`;
+export const prettyRuntime = runtime => {
+  if (runtime === 'nodejs10'){
+    return 'Node.js 10 (Unsupported)'
+  } else {
+  return functionAvailableLanguages[runtime] || `Unknown: ${runtime}`;
+  }
+}
 
 export const runtimeToMonacoEditorLang = runtime => {
   switch (runtime) {

--- a/core-ui/src/components/Lambdas/helpers/runtime/test/runtime.test.js
+++ b/core-ui/src/components/Lambdas/helpers/runtime/test/runtime.test.js
@@ -8,7 +8,6 @@ import {
 describe('prettyRuntime', () => {
   test.each([
     ['python38', 'Python 3.8'],
-    ['nodejs10', 'Node.js 10 (Deprecated)'],
     ['nodejs12', 'Node.js 12'],
     [undefined, 'Unknown: undefined'],
     [null, 'Unknown: null'],


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove Node.js 10 from the list of supported options
- Add a tooltip explaining that nodejs10 based functions cannot be reconciled


**Related issue(s)**
https://github.com/kyma-project/kyma/issues/10914